### PR TITLE
Use Grafana Canvas buttons.

### DIFF
--- a/dockerfiles/eventlog-live-otelcol/config/grafana-dashboards/eventlog-heap.json
+++ b/dockerfiles/eventlog-live-otelcol/config/grafana-dashboards/eventlog-heap.json
@@ -622,129 +622,223 @@
     },
     {
       "datasource": {
-        "type": "loki",
-        "uid": "P8E80F9AEF21F6940"
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
       },
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
         "overrides": []
       },
       "gridPos": {
         "h": 2,
-        "w": 4,
+        "w": 12,
         "x": 0,
         "y": 30
       },
-      "id": 7,
+      "id": 11,
       "options": {
-        "contentType": "application/x-www-form-urlencoded",
-        "icon": "play",
-        "isAuth": false,
-        "method": "POST",
-        "orientation": "center",
-        "payload": "service-name=$service_name",
-        "text": "Start Heap Profiling",
-        "type": "header",
-        "url": "http://localhost:30719/control/eventlog-socket/start-heap-profiling",
-        "variant": "destructive"
+        "inlineEditing": false,
+        "panZoom": false,
+        "root": {
+          "background": {
+            "color": {
+              "fixed": "transparent"
+            }
+          },
+          "border": {
+            "color": {
+              "fixed": "dark-green"
+            }
+          },
+          "constraint": {
+            "horizontal": "left",
+            "vertical": "top"
+          },
+          "elements": [
+            {
+              "background": {
+                "color": {
+                  "fixed": "transparent"
+                }
+              },
+              "border": {
+                "color": {
+                  "fixed": "dark-green"
+                }
+              },
+              "config": {
+                "align": "center",
+                "api": {
+                  "contentType": "application/x-www-form-urlencoded",
+                  "data": "service-name=${service_name}",
+                  "endpoint": "http://localhost:30719/control/eventlog-socket/request-heap-census",
+                  "headerParams": [],
+                  "method": "POST",
+                  "queryParams": [],
+                  "successMessage": "Requested Heap Census"
+                },
+                "color": {
+                  "fixed": "#F0F4FD"
+                },
+                "size": 14,
+                "style": {
+                  "variant": "destructive"
+                },
+                "text": {
+                  "fixed": "Request Heap Census",
+                  "mode": "fixed"
+                }
+              },
+              "constraint": {
+                "horizontal": "left",
+                "vertical": "top"
+              },
+              "name": "RequestHeapCensus",
+              "placement": {
+                "height": 45,
+                "left": 400,
+                "rotation": 0,
+                "top": 0,
+                "width": 195
+              },
+              "type": "button"
+            },
+            {
+              "background": {
+                "color": {
+                  "fixed": "transparent"
+                }
+              },
+              "border": {
+                "color": {
+                  "fixed": "dark-green"
+                }
+              },
+              "config": {
+                "align": "center",
+                "api": {
+                  "contentType": "application/x-www-form-urlencoded",
+                  "data": "service-name=${service_name}",
+                  "endpoint": "http://localhost:30719/control/eventlog-socket/stop-heap-profiling",
+                  "headerParams": [],
+                  "method": "POST",
+                  "queryParams": [],
+                  "successMessage": "Stopped Heap Profiling"
+                },
+                "color": {
+                  "fixed": "#F0F4FD"
+                },
+                "size": 14,
+                "style": {
+                  "variant": "destructive"
+                },
+                "text": {
+                  "fixed": "Stop Heap Profiling",
+                  "mode": "fixed"
+                }
+              },
+              "constraint": {
+                "horizontal": "left",
+                "vertical": "top"
+              },
+              "name": "StopHeapProfiling",
+              "placement": {
+                "height": 45,
+                "left": 200,
+                "top": 0,
+                "width": 195
+              },
+              "type": "button"
+            },
+            {
+              "background": {
+                "color": {
+                  "fixed": "transparent"
+                }
+              },
+              "border": {
+                "color": {
+                  "fixed": "dark-green"
+                },
+                "width": 0
+              },
+              "config": {
+                "align": "center",
+                "api": {
+                  "contentType": "application/x-www-form-urlencoded",
+                  "data": "service-name=${service_name}",
+                  "endpoint": "http://localhost:30719/control/eventlog-socket/start-heap-profiling",
+                  "headerParams": [],
+                  "method": "POST",
+                  "queryParams": [],
+                  "successMessage": "Started Heap Profiling"
+                },
+                "color": {
+                  "fixed": "#F0F4FD"
+                },
+                "size": 14,
+                "style": {
+                  "variant": "destructive"
+                },
+                "text": {
+                  "fixed": "Start Heap Profiling",
+                  "mode": "fixed"
+                }
+              },
+              "constraint": {
+                "horizontal": "left",
+                "vertical": "top"
+              },
+              "name": "StartHeapProfiling",
+              "placement": {
+                "height": 45,
+                "left": 0,
+                "top": 0,
+                "width": 195
+              },
+              "type": "button"
+            }
+          ],
+          "name": "Element 1774877699342",
+          "placement": {
+            "height": 100,
+            "left": 0,
+            "rotation": 0,
+            "top": 0,
+            "width": 100
+          },
+          "type": "frame"
+        },
+        "showAdvancedTypes": true,
+        "tooltip": {
+          "disableForOneClick": false,
+          "mode": "single"
+        },
+        "zoomToContent": false
       },
-      "pluginVersion": "7.0.23",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
-          "direction": "backward",
-          "editorMode": "builder",
-          "expr": "",
-          "queryType": "range",
           "refId": "A"
         }
       ],
       "title": "",
       "transparent": true,
-      "type": "cloudspout-button-panel"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "P8E80F9AEF21F6940"
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 4,
-        "x": 4,
-        "y": 30
-      },
-      "id": 8,
-      "options": {
-        "contentType": "application/x-www-form-urlencoded",
-        "icon": "square-shape",
-        "isAuth": false,
-        "method": "POST",
-        "orientation": "center",
-        "payload": "service-name=$service_name",
-        "text": "Stop Heap Profiling",
-        "type": "header",
-        "url": "http://localhost:30719/control/eventlog-socket/stop-heap-profiling",
-        "variant": "destructive"
-      },
-      "pluginVersion": "7.0.23",
-      "targets": [
-        {
-          "direction": "backward",
-          "editorMode": "builder",
-          "expr": "",
-          "queryType": "range",
-          "refId": "A"
-        }
-      ],
-      "title": "",
-      "transparent": true,
-      "type": "cloudspout-button-panel"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "P8E80F9AEF21F6940"
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 4,
-        "x": 8,
-        "y": 30
-      },
-      "id": 9,
-      "options": {
-        "contentType": "application/x-www-form-urlencoded",
-        "icon": "wrench",
-        "isAuth": false,
-        "method": "POST",
-        "orientation": "center",
-        "payload": "service-name=$service_name",
-        "text": "Request Heap Census",
-        "type": "header",
-        "url": "http://localhost:30719/control/eventlog-socket/request-heap-census",
-        "variant": "destructive"
-      },
-      "pluginVersion": "7.0.23",
-      "targets": [
-        {
-          "direction": "backward",
-          "editorMode": "builder",
-          "expr": "",
-          "queryType": "range",
-          "refId": "A"
-        }
-      ],
-      "title": "",
-      "transparent": true,
-      "type": "cloudspout-button-panel"
+      "type": "canvas"
     }
   ],
   "preload": false,

--- a/dockerfiles/eventlog-live-otelcol/docker-compose-external.yml
+++ b/dockerfiles/eventlog-live-otelcol/docker-compose-external.yml
@@ -9,8 +9,6 @@ services:
       interval: 1m
       timeout: 10s
       retries: 5
-    environment:
-      GF_INSTALL_PLUGINS: "https://github.com/cloudspout/cloudspout-button-panel/releases/download/7.0.23/cloudspout-button-panel.zip;cloudspout-button-panel"
     volumes:
       - "./config/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml"
       - "./config/grafana-dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml"

--- a/dockerfiles/eventlog-live-otelcol/docker-compose.yml
+++ b/dockerfiles/eventlog-live-otelcol/docker-compose.yml
@@ -41,8 +41,6 @@ services:
       interval: 1m
       timeout: 10s
       retries: 5
-    environment:
-      GF_INSTALL_PLUGINS: "https://github.com/cloudspout/cloudspout-button-panel/releases/download/7.0.23/cloudspout-button-panel.zip;cloudspout-button-panel"
     volumes:
       - "./config/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml"
       - "./config/grafana-dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml"

--- a/eventlog-live-otelcol/eventlog-live-otelcol.cabal
+++ b/eventlog-live-otelcol/eventlog-live-otelcol.cabal
@@ -175,6 +175,7 @@ library
 
   autogen-modules: Paths_eventlog_live_otelcol
   build-depends:
+    , aeson                    >=2.2    && <2.3
     , ansi-terminal            >=1.1    && <1.2
     , base                     >=4.16   && <4.22
     , binary                   >=0.8    && <0.9
@@ -192,7 +193,6 @@ library
     , hs-opentelemetry-otlp    >=0.1.0  && <0.2
     , HsYAML                   >=0.2    && <0.3
     , http-api-data            >=0.6    && <0.7
-    , http-types               >=0.12   && <0.13
     , lens-family              >=2.1.3  && <2.2
     , machines                 >=0.7.4  && <0.8
     , network                  >=3.2.7  && <3.3

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Control.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Control.hs
@@ -9,13 +9,13 @@ import Control.Concurrent (forkIO, killThread)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TVar (TVar, modifyTVar', newTVarIO, readTVarIO)
 import Control.Monad.IO.Class (MonadIO (..))
+import Data.Aeson qualified as JSON
+import Data.Aeson.Types (FromJSON (..), Parser, Value, genericParseJSON)
 import Data.Binary qualified as B
-import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as BSL
 import Data.Char (isLower, isUpper, toLower)
 import Data.HashMap.Strict (HashMap)
 import Data.HashMap.Strict qualified as M
-import Data.List qualified as L
 import Data.Proxy (Proxy (..))
 import Data.Text (Text)
 import Data.Text.Encoding qualified as TE
@@ -25,18 +25,18 @@ import GHC.Eventlog.Live.Otelcol.Options (ServiceName (..))
 import GHC.Eventlog.Live.Source.Core (EventlogSourceHandle (..))
 import GHC.Eventlog.Socket.Control qualified as C (requestHeapCensus, startHeapProfiling, stopHeapProfiling)
 import GHC.Generics (Generic)
-import Network.HTTP.Types.Header (hOrigin)
 import Network.Socket (Socket)
 import Network.Socket.ByteString.Lazy qualified as SBSL
 import Network.Wai (Middleware, Request (..))
 import Network.Wai.Handler.Warp qualified as Warp
 import Network.Wai.Middleware.Cors (CorsResourcePolicy (..), cors)
 import Network.Wai.Middleware.RequestLogger (Destination (..), DetailedSettings (..), OutputFormat (..), RequestLoggerSettings (..), defaultDetailedSettings, defaultRequestLoggerSettings, mkRequestLogger)
-import Servant (throwError)
-import Servant.API (FormUrlEncoded, Get, JSON, PostAccepted, ReqBody, (:>), type (:<|>) (..))
+import Servant (PlainText, throwError)
+import Servant.API (FormUrlEncoded, Get, Header, Headers, JSON, NoContent (..), PostAccepted, ReqBody, StdMethod (..), Verb, addHeader, (:>), type (:<|>) (..))
 import Servant.Server (Handler, Server, ServerError (..), serve)
 import System.Log.FastLogger (fromLogStr)
-import Web.FormUrlEncoded (Form, FormOptions (fieldLabelModifier), FromForm (..), defaultFormOptions, genericFromForm)
+import Web.FormUrlEncoded (Form, FormOptions, FromForm (..), genericFromForm)
+import Web.FormUrlEncoded qualified as Form (FormOptions (fieldLabelModifier), defaultFormOptions)
 
 --------------------------------------------------------------------------------
 -- Control App
@@ -91,23 +91,20 @@ mkLoggerMiddleware logger =
               }
       }
 
+-- TODO: The CORS policy should be configurable.
 corsResourcePolicy :: Request -> Maybe CorsResourcePolicy
-corsResourcePolicy req = do
-  origin <- findOrigin req
+corsResourcePolicy _req = do
   pure
     CorsResourcePolicy
-      { corsOrigins = Just ([origin], True)
+      { corsOrigins = Nothing
       , corsMethods = ["GET", "POST"]
-      , corsRequestHeaders = []
+      , corsRequestHeaders = ["Content-Type", "Origin"]
       , corsExposedHeaders = Nothing
       , corsMaxAge = Nothing -- TODO: Pick a timeout.
-      , corsVaryOrigin = True
-      , corsRequireOrigin = True
-      , corsIgnoreFailures = False
+      , corsVaryOrigin = False
+      , corsRequireOrigin = False
+      , corsIgnoreFailures = True -- TODO: Ignoring failures should be optional and linked to the badCORSPreflight handler.
       }
-
-findOrigin :: Request -> Maybe ByteString
-findOrigin = fmap snd . L.find ((hOrigin ==) . fst) . requestHeaders
 
 --------------------------------------------------------------------------------
 -- Control Server
@@ -123,7 +120,10 @@ controlServer logger eventlogSourceHandleMapVar =
       "Received request on /health."
 
   eventlogSocket :: Server EventlogSocketApi
-  eventlogSocket = startHeapProfiling :<|> stopHeapProfiling :<|> requestHeapCensus
+  eventlogSocket =
+    (startHeapProfiling :<|> badCORSPreflight)
+      :<|> (stopHeapProfiling :<|> badCORSPreflight)
+      :<|> (requestHeapCensus :<|> badCORSPreflight)
    where
     startHeapProfiling :: StartHeapProfilingReq -> Handler ()
     startHeapProfiling req = do
@@ -148,6 +148,18 @@ controlServer logger eventlogSourceHandleMapVar =
       -- Send the control command over the socket.
       withSocketFor (ServiceName req.serviceName) $ \socket -> do
         liftIO (SBSL.sendAll socket $ B.encode C.requestHeapCensus)
+
+    -- This accepts broken CORS preflight requests, such as those sent by Grafana on Safari.
+    --
+    -- TODO: This should be optional, defaulting to a 400 (Bad Request).
+    badCORSPreflight :: Handler BadCORSPreflightResp
+    badCORSPreflight = do
+      liftIO . writeLog logger DEBUG $ "Received preflight request."
+      pure $
+        addHeader "*" $
+          addHeader "GET, POST" $
+            addHeader "*" $
+              NoContent
 
     withSocketFor :: ServiceName -> (Socket -> Handler ()) -> Handler ()
     withSocketFor serviceName action = do
@@ -213,22 +225,33 @@ type HealthApi =
 
 type EventlogSocketApi =
   "eventlog-socket"
-    :> ( "start-heap-profiling" :> StartHeapProfilingApi
-          :<|> "stop-heap-profiling" :> StopHeapProfilingApi
-          :<|> "request-heap-census" :> RequestHeapCensusApi
+    :> ( "start-heap-profiling" :> (StartHeapProfilingApi :<|> BadCORSPreflight)
+          :<|> "stop-heap-profiling" :> (StopHeapProfilingApi :<|> BadCORSPreflight)
+          :<|> "request-heap-census" :> (RequestHeapCensusApi :<|> BadCORSPreflight)
        )
 
 type StartHeapProfilingApi =
-  ReqBody '[FormUrlEncoded] StartHeapProfilingReq
+  ReqBody '[FormUrlEncoded, JSON] StartHeapProfilingReq
     :> PostAccepted '[JSON] ()
 
 type StopHeapProfilingApi =
-  ReqBody '[FormUrlEncoded] StopHeapProfilingReq
+  ReqBody '[FormUrlEncoded, JSON] StopHeapProfilingReq
     :> PostAccepted '[JSON] ()
 
 type RequestHeapCensusApi =
-  ReqBody '[FormUrlEncoded] RequestHeapCensusReq
+  ReqBody '[FormUrlEncoded, JSON] RequestHeapCensusReq
     :> PostAccepted '[JSON] ()
+
+type BadCORSPreflight =
+  Verb 'OPTIONS 204 '[PlainText] BadCORSPreflightResp
+
+type BadCORSPreflightResp =
+  Headers
+    '[ Header "Access-Control-Allow-Origin" String
+     , Header "Access-Control-Allow-Methods" String
+     , Header "Access-Control-Allow-Headers" String
+     ]
+    NoContent
 
 --------------------------------------------------------------------------------
 -- Health
@@ -250,6 +273,10 @@ instance FromForm StartHeapProfilingReq where
   fromForm :: Form -> Either Text StartHeapProfilingReq
   fromForm = genericFromForm myFormOptions
 
+instance FromJSON StartHeapProfilingReq where
+  parseJSON :: Value -> Parser StartHeapProfilingReq
+  parseJSON = genericParseJSON myJSONOptions
+
 --------------------------------------------------------------------------------
 -- StopHeapProfilingReq
 --------------------------------------------------------------------------------
@@ -262,6 +289,10 @@ newtype StopHeapProfilingReq = StopHeapProfilingReq
 instance FromForm StopHeapProfilingReq where
   fromForm :: Form -> Either Text StopHeapProfilingReq
   fromForm = genericFromForm myFormOptions
+
+instance FromJSON StopHeapProfilingReq where
+  parseJSON :: Value -> Parser StopHeapProfilingReq
+  parseJSON = genericParseJSON myJSONOptions
 
 --------------------------------------------------------------------------------
 -- RequestHeapCensusReq
@@ -276,15 +307,27 @@ instance FromForm RequestHeapCensusReq where
   fromForm :: Form -> Either Text RequestHeapCensusReq
   fromForm = genericFromForm myFormOptions
 
-myFormOptions :: FormOptions
-myFormOptions =
-  defaultFormOptions
-    { fieldLabelModifier = camelTo2 '-'
-    }
+instance FromJSON RequestHeapCensusReq where
+  parseJSON :: Value -> Parser RequestHeapCensusReq
+  parseJSON = genericParseJSON myJSONOptions
 
 --------------------------------------------------------------------------------
 -- Internal helpers.
 --------------------------------------------------------------------------------
+
+-- | Generic options for `FromForm`.
+myFormOptions :: FormOptions
+myFormOptions =
+  Form.defaultFormOptions
+    { Form.fieldLabelModifier = camelTo2 '-'
+    }
+
+-- | Generic options for `FromJSON`.
+myJSONOptions :: JSON.Options
+myJSONOptions =
+  JSON.defaultOptions
+    { JSON.fieldLabelModifier = camelTo2 '-'
+    }
 
 -- | Taken from aeson.
 camelTo2 :: Char -> String -> String


### PR DESCRIPTION
This PR switches drops the Cloudspout button plugin from the demo and uses the experimental Grafana Canvas buttons.

Furthermore, this PR adds a workaround for accepting bad CORS preflight requests as issue by Safari for localhost.