### PR TITLE
Enable standalone Nix package builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,13 +153,58 @@ jobs:
           - "oddball"
 
   #############################################################################
-  # Build Nix VM
+  # Build Nix Packages
   #############################################################################
 
-  build-nix-vm:
-    name: "Build Nix VM"
+  build-nix-packages:
+    name: |
+      ${{ format(
+            'Build Nix package ({0}/{1})',
+            matrix.package.root,
+            matrix.package.name
+          )
+       }}
     runs-on: "ubuntu-latest"
-    if: github.ref_name == 'master' && github.event_name == 'push'
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: 🛠️ Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixpkgs-unstable
+
+      - name: 🏗️ Build
+        run: nix build .#${{ matrix.package.name }}
+        working-directory: "nix/${{ matrix.package.root }}"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - root: "eventlog-live-otelcol"
+            name: "eventlog-live"
+          - root: "eventlog-live-otelcol"
+            name: "eventlog-live-otelcol"
+          - root: "eventlog-live-otelcol"
+            name: "oddball"
+
+  #############################################################################
+  # Build Nix VMs
+  #############################################################################
+
+  build-nix-vms:
+    name: |
+      ${{ format(
+            'Build Nix VM ({0}/{1})',
+            matrix.package.root,
+            matrix.package.name
+          )
+       }}
+    runs-on: "ubuntu-latest"
+    if: ${{ github.ref_name == 'master' && github.event_name == 'push' }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
@@ -177,14 +222,14 @@ jobs:
           nix_path: nixpkgs=channel:nixpkgs-unstable
 
       - name: 🏗️ Build
-        run: nix build .#standalone-vm
-        working-directory: "nix/${{ matrix.nix-vm-directory }}"
+        run: nix build .#${{ matrix.package.name }}
+        working-directory: "nix/${{ matrix.package.root }}"
 
       - name: 📦 Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: "${{ matrix.nix-vm-directory }}.qcow2"
-          path: "${{ github.workspace }}/nix/${{ matrix.nix-vm-directory }}/result/nixos.qcow2"
+          name: "${{ matrix.package.root }}.qcow2"
+          path: "${{ github.workspace }}/nix/${{ matrix.package.root }}/result/nixos.qcow2"
           if-no-files-found: error
           compression-level: 9
           overwrite: true
@@ -192,8 +237,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nix-vm-directory:
-          - "eventlog-live-otelcol"
+        package:
+          - root: "eventlog-live-otelcol"
+            name: "standalone-vm"
 
   #############################################################################
   # Test with cabal-docspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,9 +172,23 @@ jobs:
           submodules: true
 
       - name: 🛠️ Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: nixbuild/nix-quick-install-action@v30
         with:
-          nix_path: nixpkgs=channel:nixpkgs-unstable
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+
+      - name: 💾 Cache Nix Store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ matrix.package.root }}-${{ matrix.package.name }}-${{ hashFiles('nix/${{ matrix.package.root }}/*.nix', 'nix/${{ matrix.package.root }}/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-created: 0
+          purge-last-accessed: P1DT12H
+          purge-primary-key: never
 
       - name: 🏗️ Build
         run: nix build .#${{ matrix.package.name }}

--- a/nix/eventlog-live-otelcol/README.md
+++ b/nix/eventlog-live-otelcol/README.md
@@ -2,6 +2,38 @@
 
 This directory contains a NixOS configuration that builds a QEMU virtual machine corresponding to [the demo described in the README](https://github.com/well-typed/eventlog-live#demo), which sets up `eventlog-live-otelcol`, the `oddball` example program, the OpenTelemetry Collector, the Prometheus metric processor and database, the Tempo span processor and database, and Grafana.
 
+## Building the packages
+
+The configuration contains three Nix packages:
+
+- `eventlog-live`
+- `eventlog-live-otelcol`
+- `oddball`
+
+These packages can be built from command-line:
+
+```sh
+# build eventlog-live:
+nix build .#eventlog-live
+
+# build eventlog-live-otelcol:
+nix build .#eventlog-live-otelcol
+
+# build oddball:
+nix build .#oddball
+```
+
+The `eventlog-live` and `oddball` packages should build on any supported platform.
+Unfortunately, `eventlog-live-otelcol` depends on the `crc32c` package, which does not have Nix derivations for `arm64` architectures.
+
+> [!NOTE]
+> These Nix commands use the `nix-command` and `flakes` features.
+> On any system where these aren't enabled by default, this requires the following extra command-line options:
+>
+> ```sh
+> --extra-experimental-features nix-command flakes
+> ```
+
 ## Building the VM
 
 Building the VM requires a linux machine running [Nix](https://nixos.org) with flakes enabled.

--- a/nix/eventlog-live-otelcol/configuration.nix
+++ b/nix/eventlog-live-otelcol/configuration.nix
@@ -1,30 +1,11 @@
 {
-  config,
   pkgs,
-  lib,
   all-cabal-hashes,
   ...
 }:
 
 let
-  # Use GHC 9.10.1 with updated all-cabal-hashes
-  haskellPackages =
-    (pkgs.haskell.packages.ghc9103.override { all-cabal-hashes = all-cabal-hashes; }).extend
-      ((import ./overlay.nix) (pkgs));
-
-  # Build the eventlog-live project
-  eventlog-live =
-    haskellPackages.callCabal2nix "eventlog-live" (pkgs.lib.cleanSource ../../eventlog-live)
-      { };
-
-  # Build the oddball example
-  oddball = haskellPackages.callCabal2nix "oddball" (pkgs.lib.cleanSource ../../examples/oddball) { };
-
-  # Build the eventlog-live-otelcol
-  eventlog-live-otelcol =
-    haskellPackages.callCabal2nix "eventlog-live-otelcol"
-      (pkgs.lib.cleanSource ../../eventlog-live-otelcol)
-      { inherit eventlog-live; };
+  inherit (import ./default.nix { inherit pkgs all-cabal-hashes; }) oddball eventlog-live-otelcol;
 in
 {
   imports = [

--- a/nix/eventlog-live-otelcol/configuration.nix
+++ b/nix/eventlog-live-otelcol/configuration.nix
@@ -1,8 +1,4 @@
-{
-  pkgs,
-  all-cabal-hashes,
-  ...
-}:
+{ pkgs, all-cabal-hashes, ... }:
 
 let
   inherit (import ./default.nix { inherit pkgs all-cabal-hashes; }) oddball eventlog-live-otelcol;

--- a/nix/eventlog-live-otelcol/default.nix
+++ b/nix/eventlog-live-otelcol/default.nix
@@ -1,9 +1,11 @@
-{pkgs, all-cabal-hashes, ...}: let 
+{ pkgs, all-cabal-hashes, ... }:
+let
   haskellPackages = pkgs.haskell.packages.ghc9103.override {
     inherit all-cabal-hashes;
     overrides = import ./overlay.nix { hlib = pkgs.haskell.lib.compose; };
   };
-in rec {
+in
+rec {
   inherit (haskellPackages) oddball eventlog-live eventlog-live-otelcol;
   eventlog-live-otelcol-control = eventlog-live-otelcol.override { withControl = true; };
 }

--- a/nix/eventlog-live-otelcol/default.nix
+++ b/nix/eventlog-live-otelcol/default.nix
@@ -1,0 +1,9 @@
+{pkgs, all-cabal-hashes, ...}: let 
+  haskellPackages = pkgs.haskell.packages.ghc9103.override {
+    inherit all-cabal-hashes;
+    overrides = import ./overlay.nix { hlib = pkgs.haskell.lib.compose; };
+  };
+in rec {
+  inherit (haskellPackages) oddball eventlog-live eventlog-live-otelcol;
+  eventlog-live-otelcol-control = eventlog-live-otelcol.override { withControl = true; };
+}

--- a/nix/eventlog-live-otelcol/eventlog-live-otelcol.nix
+++ b/nix/eventlog-live-otelcol/eventlog-live-otelcol.nix
@@ -1,5 +1,9 @@
-{ withControl ?  false , callCabal2nixWithOptions , lib, ... }: callCabal2nixWithOptions 
-  "eventlog-live-otelcol" 
-  (lib.cleanSource ../../eventlog-live-otelcol) 
-  (lib.optionalString withControl "-fcontrol") 
+{
+  withControl ? false,
+  callCabal2nixWithOptions,
+  lib,
+  ...
+}:
+callCabal2nixWithOptions "eventlog-live-otelcol" (lib.cleanSource ../../eventlog-live-otelcol)
+  (lib.optionalString withControl "-fcontrol")
   { }

--- a/nix/eventlog-live-otelcol/eventlog-live-otelcol.nix
+++ b/nix/eventlog-live-otelcol/eventlog-live-otelcol.nix
@@ -1,0 +1,5 @@
+{ withControl ?  false , callCabal2nixWithOptions , lib, ... }: callCabal2nixWithOptions 
+  "eventlog-live-otelcol" 
+  (lib.cleanSource ../../eventlog-live-otelcol) 
+  (lib.optionalString withControl "-fcontrol") 
+  { }

--- a/nix/eventlog-live-otelcol/eventlog-live.nix
+++ b/nix/eventlog-live-otelcol/eventlog-live.nix
@@ -1,0 +1,1 @@
+{ callCabal2nix, lib, ... }: callCabal2nix "eventlog-live" (lib.cleanSource ../../eventlog-live) { }

--- a/nix/eventlog-live-otelcol/flake.lock
+++ b/nix/eventlog-live-otelcol/flake.lock
@@ -3,11 +3,11 @@
     "all-cabal-hashes": {
       "flake": false,
       "locked": {
-        "lastModified": 1772714106,
-        "narHash": "sha256-X1jXqkXE9c25Yex9jV1PAnw7oF2DC7dGClfyp+aW/FM=",
+        "lastModified": 1775828251,
+        "narHash": "sha256-sjmX3ckK4qUEn+4MsNuqCZx54xedneFJ03fHSoPQo4Y=",
         "owner": "commercialhaskell",
         "repo": "all-cabal-hashes",
-        "rev": "5fd38da17eb47aa9eebe7e1ce6240a743ea3fe00",
+        "rev": "2c17abd2c6ca2e5d58926cca0a743fc53898a34c",
         "type": "github"
       },
       "original": {
@@ -71,11 +71,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772624091,
-        "narHash": "sha256-QKyJ0QGWBn6r0invrMAK8dmJoBYWoOWy7lN+UHzW1jc=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "80bdc1e5ce51f56b19791b52b2901187931f5353",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {

--- a/nix/eventlog-live-otelcol/flake.nix
+++ b/nix/eventlog-live-otelcol/flake.nix
@@ -41,8 +41,12 @@
           config = systemConfig;
           standalone-vm = generator "qcow";
           vm = nixosConfig.config.system.build.vm;
-          inherit (import ./default.nix { inherit pkgs all-cabal-hashes; }) 
-            oddball eventlog-live eventlog-live-otelcol eventlog-live-otelcol-control;
+          inherit (import ./default.nix { inherit pkgs all-cabal-hashes; })
+            oddball
+            eventlog-live
+            eventlog-live-otelcol
+            eventlog-live-otelcol-control
+            ;
         };
 
         # Development shell

--- a/nix/eventlog-live-otelcol/flake.nix
+++ b/nix/eventlog-live-otelcol/flake.nix
@@ -41,6 +41,8 @@
           config = systemConfig;
           standalone-vm = generator "qcow";
           vm = nixosConfig.config.system.build.vm;
+          inherit (import ./default.nix { inherit pkgs all-cabal-hashes; }) 
+            oddball eventlog-live eventlog-live-otelcol eventlog-live-otelcol-control;
         };
 
         # Development shell

--- a/nix/eventlog-live-otelcol/oddball.nix
+++ b/nix/eventlog-live-otelcol/oddball.nix
@@ -1,0 +1,1 @@
+{ callCabal2nix, lib, ... }: callCabal2nix "oddball" (lib.cleanSource ../../examples/oddball) { }

--- a/nix/eventlog-live-otelcol/overlay.nix
+++ b/nix/eventlog-live-otelcol/overlay.nix
@@ -1,8 +1,9 @@
-{hlib, ...}: final: prev: with hlib; {
+{ hlib, ... }:
+final: prev: with hlib; {
 
-  eventlog-live = final.callPackage ./eventlog-live.nix {};
-  eventlog-live-otelcol = final.callPackage ./eventlog-live-otelcol.nix {};
-  oddball = final.callPackage ./oddball.nix {};
+  eventlog-live = final.callPackage ./eventlog-live.nix { };
+  eventlog-live-otelcol = final.callPackage ./eventlog-live-otelcol.nix { };
+  oddball = final.callPackage ./oddball.nix { };
 
   # Jailbreak proto-lens to allow it to build with newer dependencies
   grapesy = dontCheck prev.grapesy;

--- a/nix/eventlog-live-otelcol/overlay.nix
+++ b/nix/eventlog-live-otelcol/overlay.nix
@@ -1,15 +1,20 @@
-pkgs: final: prev: {
+{hlib, ...}: final: prev: with hlib; {
+
+  eventlog-live = final.callPackage ./eventlog-live.nix {};
+  eventlog-live-otelcol = final.callPackage ./eventlog-live-otelcol.nix {};
+  oddball = final.callPackage ./oddball.nix {};
+
   # Jailbreak proto-lens to allow it to build with newer dependencies
-  grapesy = pkgs.haskell.lib.dontCheck prev.grapesy;
+  grapesy = dontCheck prev.grapesy;
   http2 = prev.callHackage "http2" "5.3.9" { };
   http2-tls = prev.callHackage "http2-tls" "0.4.5" { };
   eventlog-socket = prev.callHackage "eventlog-socket" "0.1.2.0" { };
   eventlog-socket-control = prev.callHackage "eventlog-socket-control" "0.1.0.0" { };
   optparse-applicative = prev.callHackage "optparse-applicative" "0.19.0.0" { };
-  proto-lens = pkgs.haskell.lib.doJailbreak prev.proto-lens;
-  proto-lens-protobuf-types = pkgs.haskell.lib.doJailbreak prev.proto-lens-protobuf-types;
+  proto-lens = doJailbreak prev.proto-lens;
+  proto-lens-protobuf-types = doJailbreak prev.proto-lens-protobuf-types;
   proto-lens-protoc = prev.callHackage "proto-lens-protoc" "0.9.0.0" { };
-  snappy-c = pkgs.haskell.lib.doJailbreak prev.snappy-c;
-  tasty-quickcheck = pkgs.haskell.lib.doJailbreak prev.tasty-quickcheck;
+  snappy-c = doJailbreak prev.snappy-c;
+  tasty-quickcheck = doJailbreak prev.tasty-quickcheck;
   tls = prev.callHackage "tls" "2.1.4" { };
 }

--- a/nix/eventlog-live-otelcol/overlay.nix
+++ b/nix/eventlog-live-otelcol/overlay.nix
@@ -9,8 +9,8 @@ final: prev: with hlib; {
   grapesy = dontCheck prev.grapesy;
   http2 = prev.callHackage "http2" "5.3.9" { };
   http2-tls = prev.callHackage "http2-tls" "0.4.5" { };
-  eventlog-socket = prev.callHackage "eventlog-socket" "0.1.2.0" { };
-  eventlog-socket-control = prev.callHackage "eventlog-socket-control" "0.1.0.0" { };
+  eventlog-socket = prev.callHackage "eventlog-socket" "0.1.3.0" { };
+  eventlog-socket-control = prev.callHackage "eventlog-socket-control" "0.1.1.0" { };
   optparse-applicative = prev.callHackage "optparse-applicative" "0.19.0.0" { };
   proto-lens = doJailbreak prev.proto-lens;
   proto-lens-protobuf-types = doJailbreak prev.proto-lens-protobuf-types;


### PR DESCRIPTION
- make packages buildable on their own
- make packages buildable from toplevel
- make eventlog-live-otelcol buildable with -fcontrol
- move packages into overlays to increase usability