### PR TITLE
Spring cleaning, part II.

### DIFF
--- a/.github/actions/setup-cabal-gild/action.yml
+++ b/.github/actions/setup-cabal-gild/action.yml
@@ -1,0 +1,48 @@
+name: "Setup cabal-gild"
+description: "Install a specific cabal-gild version"
+inputs:
+  cabal-gild-version:
+    required: true
+    description: "Version of cabal-gild"
+  ghc-version:
+    required: true
+    description: "Version of GHC"
+  cabal-version:
+    required: true
+    description: "Version of cabal"
+runs:
+  using: composite
+  steps:
+    - name: 💾 Restore cache
+      uses: actions/cache/restore@v4
+      if: ${{ !env.ACT }}
+      id: cache-cabal-gild
+      with:
+        path: "${{ github.workspace }}/.cabal-gild/bin"
+        key: ${{ runner.os }}-cabal-gild-${{ inputs.cabal-gild-version }}
+
+    - name: 🛠️ Install Haskell
+      if: ${{ env.ACT || steps.cache-cabal-gild.outputs.cache-hit != 'true' }}
+      uses: haskell-actions/setup@v2
+      id: setup-haskell
+      with:
+        ghc-version: ${{ inputs.ghc-version }}
+        cabal-version: ${{ inputs.cabal-version }}
+
+    - name: 🛠️ Install cabal-gild
+      if: ${{ env.ACT || steps.cache-cabal-gild.outputs.cache-hit != 'true' }}
+      run: |
+        mkdir --parents "${{ github.workspace }}/.cabal-gild/bin"
+        cabal install cabal-gild-${{ inputs.cabal-gild-version }} --overwrite-policy=always --install-method=copy --installdir="${{ github.workspace }}/.cabal-gild/bin"
+      shell: sh
+
+    - name: 🛠️ Add cabal-gild to PATH
+      run: echo "${{ github.workspace }}/.cabal-gild/bin" >> "$GITHUB_PATH"
+      shell: sh
+
+    - name: 💾 Save cache
+      uses: actions/cache/save@v4
+      if: ${{ !env.ACT && steps.cache-cabal-gild.outputs.cache-hit != 'true' }}
+      with:
+        path: "${{ github.workspace }}/.cabal-gild/bin"
+        key: ${{ steps.cache-cabal-gild.outputs.cache-primary-key }}

--- a/.github/actions/setup-fourmolu/action.yml
+++ b/.github/actions/setup-fourmolu/action.yml
@@ -22,7 +22,7 @@ runs:
         key: ${{ runner.os }}-fourmolu-${{ inputs.fourmolu-version }}
 
     - name: 🛠️ Install Haskell
-      if: ${{ env.ACT || steps.cache-cabal-fmt.outputs.cache-hit != 'true' }}
+      if: ${{ env.ACT || steps.cache-fourmolu.outputs.cache-hit != 'true' }}
       uses: haskell-actions/setup@v2
       with:
         ghc-version: ${{ inputs.ghc-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,11 +321,11 @@ jobs:
         run: ./scripts/lint-cabal.sh
 
   #############################################################################
-  # Lint with cabal-fmt
+  # Lint with cabal-gild
   #############################################################################
 
-  lint-cabal-fmt:
-    name: "Lint with cabal-fmt"
+  lint-cabal-gild:
+    name: "Lint with cabal-gild"
     runs-on: "ubuntu-latest"
     steps:
       - name: 📥 Checkout repository
@@ -337,15 +337,15 @@ jobs:
         run: cat "./scripts/dev-dependencies.txt" >> "$GITHUB_OUTPUT"
         id: dev-dependencies
 
-      - name: 🛠️ Install cabal-fmt
-        uses: ./.github/actions/setup-cabal-fmt
+      - name: 🛠️ Install cabal-gild
+        uses: ./.github/actions/setup-cabal-gild
         with:
-          cabal-fmt-version: ${{ steps.dev-dependencies.outputs.cabal-fmt }}
+          cabal-gild-version: ${{ steps.dev-dependencies.outputs.cabal-gild }}
           ghc-version: ${{ steps.dev-dependencies.outputs.ghc }}
           cabal-version: ${{ steps.dev-dependencies.outputs.cabal }}
 
-      - name: 🎗️ Lint with cabal-fmt
-        run: ./scripts/lint-cabal-fmt.sh
+      - name: 🎗️ Lint with cabal-gild
+        run: ./scripts/lint-cabal-gild.sh
 
   #############################################################################
   # Lint with HLint

--- a/demo-nix/README.md
+++ b/demo-nix/README.md
@@ -1,6 +1,6 @@
 # NixOS VM
 
-This directory contains a NixOS configuration that builds a QEMU virtual machine corresponding to an older version of [the demo described in the README](https://github.com/well-typed/eventlog-live#demo), which sets up `eventlog-live-otelcol`, the `oddball` example program, the OpenTelemetry Collector, the Prometheus metric processor and database, the Tempo span processor and database, and Grafana.
+This directory contains a NixOS configuration that builds a QEMU virtual machine corresponding to an older version of the [demo](demo/), which sets up `eventlog-live-otelcol`, the `oddball` example program, the OpenTelemetry Collector, the Prometheus metric processor and database, the Tempo span processor and database, and Grafana.
 
 ## Building the packages
 
@@ -49,20 +49,20 @@ There are two flavours for the VM: _standalone_ and _lightweight_:
   Hence, it cannot be run on any other machine.
   However, it is significantly smaller and faster to build development.
 
-To build a standalone image, run the following command from `nix/eventlog-live-otelcol`:
+To build a standalone image, run the following command from `demo-nix`:
 
 ```
 nix build .#standalone-vm
 ```
 
-To build a lightweight image, run the following command from the `nix/eventlog-live-otelcol` directory:
+To build a lightweight image, run the following command from the `demo-nix` directory:
 
 ```
 nix build .#vm
 ```
 
 To build standalone images for different architectures, you can use [remote builders](https://nixos.wiki/wiki/Distributed_build).
-For instance, if you have set up a remote builder for `aarch64-linux` builds, then you can build a standalone image for `aarch64-linux` by running the following command from the `nix/eventlog-live-otelcol` directory:
+For instance, if you have set up a remote builder for `aarch64-linux` builds, then you can build a standalone image for `aarch64-linux` by running the following command from the `demo-nix` directory:
 
 ```
 nix build .#packages.aarch64-linux.standalone-vm
@@ -75,7 +75,7 @@ There are two options for running the VM, depending on whether your system is ca
 ### Using Nix
 
 If your system satisfies the build prerequisites, you can run the VM via Nix.
-Run the following command from the `nix/eventlog-live-otelcol` directory:
+Run the following command from the `demo-nix` directory:
 
 ```sh
 ./run-vm.sh

--- a/eventlog-live-otelcol/eventlog-live-otelcol.cabal
+++ b/eventlog-live-otelcol/eventlog-live-otelcol.cabal
@@ -1,7 +1,7 @@
-cabal-version:      3.0
-name:               eventlog-live-otelcol
-version:            0.6.0.0
-synopsis:           Stream eventlog data to the OpenTelemetry Collector.
+cabal-version: 3.0
+name: eventlog-live-otelcol
+version: 0.6.0.0
+synopsis: Stream eventlog data to the OpenTelemetry Collector.
 description:
   This executable supports live streaming of eventlog data into
   the OpenTelemetry Collector.
@@ -74,25 +74,25 @@ description:
   >                            Enable ghc-debug for this program on the given TCP
   >                            socket specified as 'host:port'.
 
-license:            BSD-3-Clause
-license-file:       LICENSE
-author:             Wen Kokke
-maintainer:         wen@well-typed.com
-copyright:          (c) 2025 Well-Typed
-build-type:         Simple
-category:           Debug, Monitoring, System
-extra-doc-files:    CHANGELOG.md
+license: BSD-3-Clause
+license-file: LICENSE
+author: Wen Kokke
+maintainer: wen@well-typed.com
+copyright: (c) 2025 Well-Typed
+build-type: Simple
+category: Debug, Monitoring, System
+extra-doc-files: CHANGELOG.md
 extra-source-files:
   data/config.schema.json
   data/default.yaml
 
 tested-with:
-  GHC ==9.2.8 || ==9.4.8 || ==9.6.7 || ==9.8.4 || ==9.10.2
+  ghc ==9.2.8 || ==9.4.8 || ==9.6.7 || ==9.8.4 || ==9.10.2
 
 source-repository head
-  type:     git
+  type: git
   location: https://github.com/well-typed/eventlog-live.git
-  subdir:   eventlog-live-otelcol
+  subdir: eventlog-live-otelcol
 
 -- This flag enables the control command server, which is an HTTP endpoint
 -- that gets started by eventlog-live-otelcol. If +control is set, then
@@ -100,16 +100,16 @@ source-repository head
 -- set at compile-time, the control server can be enabled at runtime.
 flag control
   description: Enable control command server.
-  default:     False
-  manual:      True
+  default: False
+  manual: True
 
 -- 2026-04-02:
 -- This flag should enable switching the use of eventlog-socket on
 -- and off, since it may cause issues with certain versions of GHC.
 flag use-eventlog-socket
   description: Use eventlog-socket
-  default:     False
-  manual:      True
+  default: False
+  manual: True
 
 -- 2025-11-10:
 -- This flag should enable switching the use of ghc-debug-stub on
@@ -117,24 +117,28 @@ flag use-eventlog-socket
 -- See https://github.com/well-typed/eventlog-live/issues/88
 flag use-ghc-debug-stub
   description: Use ghc-debug-stub
-  default:     False
-  manual:      True
+  default: False
+  manual: True
 
 -- 2025-11-06:
 -- This flag should enable switching between template-haskell and
 -- template-haskell-lift, because the latter is not on nixpkgs.
 flag use-template-haskell-lift
   description: Use template-haskell-lift in place of template-haskell
-  default:     False
-  manual:      False
+  default: False
+  manual: False
 
 common language
   ghc-options:
-    -Wall -Wcompat -Widentities -Wprepositive-qualified-module
-    -Wredundant-constraints -Wunticked-promoted-constructors
+    -Wall
+    -Wcompat
+    -Widentities
+    -Wprepositive-qualified-module
+    -Wredundant-constraints
+    -Wunticked-promoted-constructors
     -Wunused-packages
 
-  default-language:   Haskell2010
+  default-language: Haskell2010
   default-extensions:
     BangPatterns
     ConstraintKinds
@@ -170,8 +174,8 @@ common language
     TypeOperators
 
 library
-  import:          language
-  hs-source-dirs:  src
+  import: language
+  hs-source-dirs: src
   exposed-modules: GHC.Eventlog.Live.Otelcol
   other-modules:
     GHC.Debug.Stub.Compat
@@ -204,68 +208,70 @@ library
 
   autogen-modules: Paths_eventlog_live_otelcol
   build-depends:
-    , ansi-terminal            >=1.1    && <1.2
-    , base                     >=4.16   && <4.22
-    , bytestring               >=0.11   && <0.13
-    , containers               >=0.6    && <0.8
-    , data-default             >=0.2    && <0.9
-    , dlist                    >=1.0    && <1.1
-    , eventlog-live            >=0.5    && <0.6
-    , file-embed               >=0.0.16 && <0.1
-    , ghc-events               >=0.20   && <0.21
-    , ghc-stack-profiler-core  >=0.2    && <0.3
-    , grapesy                  >=1.0.0  && <1.2
-    , hashable                 >=1.4    && <1.6
-    , hs-opentelemetry-otlp    >=0.2.0  && <0.3
-    , HsYAML                   >=0.2    && <0.3
-    , lens-family              >=2.1.3  && <2.2
-    , machines                 >=0.7.4  && <0.8
-    , optparse-applicative     >=0.17   && <0.20
-    , proto-lens               >=0.7.1  && <0.8
-    , random                   >=1.2    && <1.4
-    , stm                      >=2.5    && <2.6
-    , strict-list              >=0.1    && <0.2
-    , table-layout             >=1.0    && <1.1
-    , text                     >=1.2    && <2.2
-    , transformers             >=0.2    && <0.7
-    , unordered-containers     >=0.2.20 && <0.3
-    , vector                   >=0.11   && <0.14
+    ansi-terminal >=1.1 && <1.2,
+    base >=4.16 && <4.22,
+    bytestring >=0.11 && <0.13,
+    containers >=0.6 && <0.8,
+    data-default >=0.2 && <0.9,
+    dlist >=1.0 && <1.1,
+    eventlog-live >=0.5 && <0.6,
+    file-embed >=0.0.16 && <0.1,
+    ghc-events >=0.20 && <0.21,
+    ghc-stack-profiler-core >=0.2 && <0.3,
+    grapesy >=1.0.0 && <1.2,
+    hashable >=1.4 && <1.6,
+    hs-opentelemetry-otlp >=0.2.0 && <0.3,
+    HsYAML >=0.2 && <0.3,
+    lens-family >=2.1.3 && <2.2,
+    machines >=0.7.4 && <0.8,
+    optparse-applicative >=0.17 && <0.20,
+    proto-lens >=0.7.1 && <0.8,
+    random >=1.2 && <1.4,
+    stm >=2.5 && <2.6,
+    strict-list >=0.1 && <0.2,
+    table-layout >=1.0 && <1.1,
+    text >=1.2 && <2.2,
+    transformers >=0.2 && <0.7,
+    unordered-containers >=0.2.20 && <0.3,
+    vector >=0.11 && <0.14,
 
   if flag(control)
     build-depends:
-      , aeson                    >=2.2   && <2.3
-      , binary                   >=0.8   && <0.9
-      , eventlog-socket-control  >=0.1.1 && <0.2
-      , fast-logger              >=3.0   && <3.3
-      , http-api-data            >=0.6   && <0.7
-      , network                  >=3.2.7 && <3.3
-      , servant                  >=0.20  && <0.21
-      , servant-server           >=0.20  && <0.21
-      , wai                      >=3.2   && <3.3
-      , wai-cors                 >=0.2   && <0.3
-      , wai-extra                >=3.1   && <3.2
-      , warp                     >=3.4   && <3.5
+      aeson >=2.2 && <2.3,
+      binary >=0.8 && <0.9,
+      eventlog-socket-control >=0.1.1 && <0.2,
+      fast-logger >=3.0 && <3.3,
+      http-api-data >=0.6 && <0.7,
+      network >=3.2.7 && <3.3,
+      servant >=0.20 && <0.21,
+      servant-server >=0.20 && <0.21,
+      wai >=3.2 && <3.3,
+      wai-cors >=0.2 && <0.3,
+      wai-extra >=3.1 && <3.2,
+      warp >=3.4 && <3.5,
 
-    cpp-options:   -DEVENTLOG_LIVE_OTELCOL_FEATURE_CONTROL
+    cpp-options: -DEVENTLOG_LIVE_OTELCOL_FEATURE_CONTROL
 
   if flag(use-eventlog-socket)
     build-depends: eventlog-socket >=0.1.2 && <0.2
-    cpp-options:   -DEVENTLOG_LIVE_OTELCOL_USE_EVENTLOG_SOCKET
+    cpp-options: -DEVENTLOG_LIVE_OTELCOL_USE_EVENTLOG_SOCKET
 
   if flag(use-ghc-debug-stub)
     build-depends: ghc-debug-stub >=0.1 && <1.0
-    cpp-options:   -DEVENTLOG_LIVE_OTELCOL_USE_GHC_DEBUG_STUB
+    cpp-options: -DEVENTLOG_LIVE_OTELCOL_USE_GHC_DEBUG_STUB
 
   if flag(use-template-haskell-lift)
     build-depends: template-haskell-lift >=0.1 && <0.2
-    cpp-options:   -DEVENTLOG_LIVE_OTELCOL_USE_TEMPLATE_HASKELL_LIFT
-
+    cpp-options: -DEVENTLOG_LIVE_OTELCOL_USE_TEMPLATE_HASKELL_LIFT
   else
     build-depends: template-haskell >=2.2 && <3.0
 
 executable eventlog-live-otelcol
-  import:         language
-  main-is:        Main.hs
+  import: language
+  main-is: Main.hs
   hs-source-dirs: app
-  build-depends:  eventlog-live-otelcol
-  ghc-options:    -threaded -rtsopts -finfo-table-map
+  build-depends: eventlog-live-otelcol
+  ghc-options:
+    -threaded
+    -rtsopts
+    -finfo-table-map

--- a/eventlog-live-otelcol/eventlog-live-otelcol.cabal
+++ b/eventlog-live-otelcol/eventlog-live-otelcol.cabal
@@ -185,8 +185,15 @@ library
     GHC.Eventlog.Live.Otelcol.Exporter.Profiles
     GHC.Eventlog.Live.Otelcol.Exporter.Traces
     GHC.Eventlog.Live.Otelcol.Options
+    GHC.Eventlog.Live.Otelcol.Processor.Common.Core
+    GHC.Eventlog.Live.Otelcol.Processor.Common.Logs
+    GHC.Eventlog.Live.Otelcol.Processor.Common.Metrics
+    GHC.Eventlog.Live.Otelcol.Processor.Common.Profiles
+    GHC.Eventlog.Live.Otelcol.Processor.Common.Traces
+    GHC.Eventlog.Live.Otelcol.Processor.Heap
+    GHC.Eventlog.Live.Otelcol.Processor.Logs
     GHC.Eventlog.Live.Otelcol.Processor.Profiles
-    GHC.Eventlog.Live.Otelcol.Processor.Profiles.Dictionary
+    GHC.Eventlog.Live.Otelcol.Processor.Threads
     GHC.Eventlog.Live.Otelcol.Stats
     GHC.Eventlog.Socket.Compat
     Language.Haskell.TH.Lift.Compat

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol.hs
@@ -13,89 +13,60 @@ module GHC.Eventlog.Live.Otelcol (
 
 import Control.Concurrent.STM.TChan (newTChanIO)
 import Control.Exception (bracket_)
-import Control.Monad (unless)
-import Control.Monad.IO.Class (MonadIO (..))
-import Data.ByteString (ByteString)
-import Data.Coerce (Coercible, coerce)
 import Data.DList (DList)
 import Data.DList qualified as D
 import Data.Default (Default (..))
 import Data.Foldable qualified as F
-import Data.Functor ((<&>))
-import Data.HashMap.Strict qualified as M
-import Data.Hashable (Hashable)
-import Data.Int (Int16, Int32, Int64, Int8)
-import Data.Kind (Type)
-import Data.Machine (MachineT, Process, ProcessT, asParts, await, construct, echo, mapping, repeatedly, stopped, yield, (~>))
-import Data.Machine.Fanout (fanout)
+import Data.Machine (Process, ProcessT, asParts, mapping, (~>))
 import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
-import Data.ProtoLens (Message (defMessage))
-import Data.Proxy (Proxy (..))
-import Data.Semigroup (Last (..), Sum (..))
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Version (showVersion)
-import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Debug.Stub.Compat (withMyGhcDebug)
-import GHC.Eventlog.Live.Data.Attribute
-import GHC.Eventlog.Live.Data.Group (Group, GroupBy, GroupedBy)
-import GHC.Eventlog.Live.Data.Group qualified as DG
+import GHC.Eventlog.Live.Data.Attribute (AttrValue (AttrText), (~=))
 import GHC.Eventlog.Live.Data.LogRecord (LogRecord (..))
-import GHC.Eventlog.Live.Data.Metric (Metric (..), SomeMetric (..))
 import GHC.Eventlog.Live.Data.Severity (Severity (..))
-import GHC.Eventlog.Live.Data.Severity qualified as DS (SeverityNumber (..), toSeverityNumber)
-import GHC.Eventlog.Live.Logger (Logger, MyTelemetryData, writeLog)
+import GHC.Eventlog.Live.Logger (MyTelemetryData, writeLog)
 import GHC.Eventlog.Live.Logger qualified as M
-import GHC.Eventlog.Live.Machine.Analysis.Capability (CapabilityUsageSpan)
-import GHC.Eventlog.Live.Machine.Analysis.Capability qualified as M
-import GHC.Eventlog.Live.Machine.Analysis.Heap (MemReturnData (..))
-import GHC.Eventlog.Live.Machine.Analysis.Heap qualified as M
-import GHC.Eventlog.Live.Machine.Analysis.Log qualified as M
 import GHC.Eventlog.Live.Machine.Analysis.Profile qualified as M
-import GHC.Eventlog.Live.Machine.Analysis.Thread (ThreadStateSpan (..))
-import GHC.Eventlog.Live.Machine.Analysis.Thread qualified as M
 import GHC.Eventlog.Live.Machine.Core (Tick)
 import GHC.Eventlog.Live.Machine.Core qualified as M
-import GHC.Eventlog.Live.Machine.WithStartTime (WithStartTime (..))
 import GHC.Eventlog.Live.Machine.WithStartTime qualified as M
-import GHC.Eventlog.Live.Otelcol.Config (FullConfig (..))
 import GHC.Eventlog.Live.Otelcol.Config qualified as C
+import GHC.Eventlog.Live.Otelcol.Config.Types (FullConfig (..))
 import GHC.Eventlog.Live.Otelcol.Control (ControlServerApi (..), startControlServer)
 import GHC.Eventlog.Live.Otelcol.Exporter.Logs (exportResourceLogs)
 import GHC.Eventlog.Live.Otelcol.Exporter.Metrics (exportResourceMetrics)
 import GHC.Eventlog.Live.Otelcol.Exporter.Profiles (exportResourceProfiles)
 import GHC.Eventlog.Live.Otelcol.Exporter.Traces (exportResourceSpans)
 import GHC.Eventlog.Live.Otelcol.Options
-import GHC.Eventlog.Live.Otelcol.Processor.Profiles (processCallStackData)
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Core
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Logs (ToLogRecord (..), toExportLogsServiceRequest, toResourceLogs, toScopeLogs)
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Metrics (toExportMetricsServiceRequest, toResourceMetrics, toScopeMetrics)
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Profiles (toExportProfileServiceRequest)
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Traces (toExportTracesServiceRequest, toResourceSpans, toScopeSpans)
+import GHC.Eventlog.Live.Otelcol.Processor.Heap (processHeapEvents)
+import GHC.Eventlog.Live.Otelcol.Processor.Logs (processLogEvents)
+import GHC.Eventlog.Live.Otelcol.Processor.Profiles (processCallStackData, processProfileEvents)
+import GHC.Eventlog.Live.Otelcol.Processor.Threads (processThreadEvents)
 import GHC.Eventlog.Live.Otelcol.Stats (Stat (..), eventCountTick, processStats)
 import GHC.Eventlog.Live.Source (runWithEventlogSourceHandle, withEventlogSourceHandle)
 import GHC.Eventlog.Socket.Compat (startMyEventlogSocket)
-import GHC.RTS.Events (Event (..), HeapProfBreakdown (..), ThreadId)
-import GHC.Records (HasField (..))
-import GHC.TypeLits (Symbol)
-import Lens.Family2 ((&), (.~), (^.))
+import GHC.RTS.Events (Event (..))
+import Lens.Family2 ((.~))
 import Network.GRPC.Client qualified as G
 import Network.GRPC.Common qualified as G
 import Options.Applicative qualified as O
 import Paths_eventlog_live_otelcol qualified as EventlogLive
-import Proto.Opentelemetry.Proto.Collector.Logs.V1.LogsService qualified as OLS
-import Proto.Opentelemetry.Proto.Collector.Metrics.V1.MetricsService qualified as OMS
-import Proto.Opentelemetry.Proto.Collector.Profiles.V1development.ProfilesService qualified as OPS
 import Proto.Opentelemetry.Proto.Collector.Profiles.V1development.ProfilesService_Fields qualified as OPS
-import Proto.Opentelemetry.Proto.Collector.Trace.V1.TraceService qualified as OTS
-import Proto.Opentelemetry.Proto.Collector.Trace.V1.TraceService_Fields qualified as OTS
 import Proto.Opentelemetry.Proto.Common.V1.Common qualified as OC
 import Proto.Opentelemetry.Proto.Common.V1.Common_Fields qualified as OC
 import Proto.Opentelemetry.Proto.Logs.V1.Logs qualified as OL
-import Proto.Opentelemetry.Proto.Logs.V1.Logs_Fields qualified as OL
 import Proto.Opentelemetry.Proto.Metrics.V1.Metrics qualified as OM
 import Proto.Opentelemetry.Proto.Metrics.V1.Metrics_Fields qualified as OM
 import Proto.Opentelemetry.Proto.Profiles.V1development.Profiles qualified as OP
 import Proto.Opentelemetry.Proto.Resource.V1.Resource qualified as OR
 import Proto.Opentelemetry.Proto.Trace.V1.Trace qualified as OT
-import Proto.Opentelemetry.Proto.Trace.V1.Trace_Fields qualified as OT
-import System.Random (StdGen, initStdGen)
-import System.Random.Compat (uniformByteString)
 
 {- |
 The main function for @eventlog-live-otelcol@.
@@ -275,7 +246,7 @@ exportResourceTelemetryData fullConfig connection =
           --       streams. However, it has the "unfortunate" side-effect of
           --       making it impossible to not batch once per interval.
           ~> M.batchByTick
-          ~> M.liftTick (mapping D.toList ~> asExportLogsServiceRequest)
+          ~> M.liftTick (mapping (toExportLogsServiceRequest . D.toList))
           ~> exportResourceLogs connection
           ~> M.liftTick (mapping (D.singleton . ExportLogsResultStat))
     , -- Export metrics.
@@ -283,7 +254,7 @@ exportResourceTelemetryData fullConfig connection =
         M.liftTick (mapping getResourceMetrics ~> asParts ~> mapping D.singleton)
           -- NOTE: See note above.
           ~> M.batchByTick
-          ~> M.liftTick (mapping D.toList ~> asExportMetricsServiceRequest)
+          ~> M.liftTick (mapping (toExportMetricsServiceRequest . D.toList))
           ~> exportResourceMetrics connection
           ~> M.liftTick (mapping (D.singleton . ExportMetricsResultStat))
     , -- Export spans.
@@ -291,13 +262,12 @@ exportResourceTelemetryData fullConfig connection =
         M.liftTick (mapping getResourceSpans ~> asParts ~> mapping D.singleton)
           -- NOTE: See note above.
           ~> M.batchByTick
-          ~> M.liftTick (mapping D.toList ~> asExportTracesServiceRequest)
+          ~> M.liftTick (mapping (toExportTracesServiceRequest . D.toList))
           ~> exportResourceSpans connection
           ~> M.liftTick (mapping (D.singleton . ExportTraceResultStat))
     , -- Export profiles.
       runIf (C.shouldExportProfiles fullConfig) $
-        M.liftTick (mapping getResourceProfiles ~> asParts)
-          ~> M.liftTick asExportProfileServiceRequest
+        M.liftTick (mapping getResourceProfiles ~> asParts ~> mapping toExportProfileServiceRequest)
           ~> exportResourceProfiles connection
           ~> M.liftTick (mapping (D.singleton . ExportProfileResultStat))
     ]
@@ -356,9 +326,8 @@ asResourceTelemetryData resource instrumentationScope =
       pure $ ResourceTelemetryData'Span resourceSpans
     maybeProfiles = do
       (resourceProfile, dictionary) <-
-        ifNonEmpty
-          profiles
-          (processCallStackData resource instrumentationScope profiles)
+        ifNonEmpty profiles $
+          processCallStackData resource instrumentationScope profiles
       pure $
         ResourceTelemetryData'Profile $
           messageWith
@@ -400,504 +369,8 @@ getMyLogRecord = \case
   M.MyTelemetryData'LogRecord{..} -> Just logRecord
   M.MyTelemetryData'Metric{} -> Nothing
 
--- 2025-12-09:
--- This function is currently unused, but will be required when migrating
--- the internal metrics, i.e., Stats, over to use the new internal logger.
-_getMySomeMetric :: MyTelemetryData -> Maybe SomeMetric
-_getMySomeMetric = \case
-  M.MyTelemetryData'LogRecord{} -> Nothing
-  M.MyTelemetryData'Metric{..} -> Just metric
-
 --------------------------------------------------------------------------------
--- processThreadEvents
---------------------------------------------------------------------------------
-
-data OneOf a b c = A !a | B !b | C !c
-
-processThreadEvents ::
-  (MonadIO m) =>
-  Logger m ->
-  FullConfig ->
-  ProcessT m (Tick (WithStartTime Event)) (Tick (DList (Either OM.Metric OT.Span)))
-processThreadEvents verbosity fullConfig =
-  runIf (shouldProcessThreadEvents fullConfig) $
-    M.sortByTicks (.value.evTime) fullConfig.eventlogFlushIntervalX
-      ~> M.liftTick
-        ( fanout
-            [ M.validateOrder verbosity (.value.evTime)
-            , runIf (shouldComputeCapabilityUsageSpan fullConfig) $
-                M.processGCSpans verbosity
-                  ~> mapping (D.singleton . A)
-            , runIf (shouldComputeThreadStateSpan fullConfig) $
-                M.processThreadStateSpans' M.tryGetTimeUnixNano (.value) M.setWithStartTime'value verbosity
-                  ~> fanout
-                    [ M.asMutatorSpans' (.value) M.setWithStartTime'value
-                        ~> mapping (D.singleton . B)
-                    , mapping (D.singleton . C)
-                    ]
-            ]
-        )
-      ~> M.liftTick
-        ( asParts
-            ~> mapping repackCapabilityUsageSpanOrThreadStateSpan
-        )
-      ~> fanout
-        [ M.liftTick
-            ( mapping leftToMaybe
-                ~> asParts
-            )
-            ~> M.fanoutTick
-              [ runMetricProcessor
-                  MetricProcessor
-                    { metricProcessorProxy = Proxy @"capabilityUsage"
-                    , dataProcessor = M.processCapabilityUsageMetrics
-                    , aggregators = viaSum
-                    , postProcessor = echo
-                    , unit = "ns"
-                    , asMetric'Data =
-                        asSum
-                          [ OM.aggregationTemporality .~ OM.AGGREGATION_TEMPORALITY_DELTA
-                          , OM.isMonotonic .~ True
-                          ]
-                    }
-                  fullConfig
-                  ~> mapping (fmap (fmap Left))
-              , runIf (C.processorEnabled (.traces) (.capabilityUsage) fullConfig) $
-                  M.liftTick
-                    ( M.dropStartTime
-                        ~> asSpan fullConfig
-                        ~> mapping (D.singleton . Right)
-                    )
-                    ~> M.batchByTick
-              ]
-        , runIf (C.processorEnabled (.traces) (.threadState) fullConfig) $
-            M.liftTick
-              ( mapping rightToMaybe
-                  ~> asParts
-                  ~> asSpan fullConfig
-                  ~> mapping (D.singleton . Right)
-              )
-              ~> M.batchByTick
-        ]
- where
-  repackCapabilityUsageSpanOrThreadStateSpan = \case
-    A i -> Left $ fmap Left i
-    B i -> Left $ fmap Right i
-    C i -> Right i.value
-
-{- |
-Internal helper.
-Get the `Left` value, if any.
--}
-leftToMaybe :: Either a b -> Maybe a
-leftToMaybe = either Just (const Nothing)
-
-{- |
-Internal helper.
-Get the `Right` value, if any.
--}
-rightToMaybe :: Either a b -> Maybe b
-rightToMaybe = either (const Nothing) Just
-
-{- |
-Internal helper.
-Determine whether or not any thread events should be processed at all.
--}
-shouldProcessThreadEvents :: FullConfig -> Bool
-shouldProcessThreadEvents fullConfig =
-  C.processorEnabled (.metrics) (.capabilityUsage) fullConfig
-    || C.processorEnabled (.traces) (.capabilityUsage) fullConfig
-    || C.processorEnabled (.traces) (.threadState) fullConfig
-
-{- |
-Internal helper.
-Determine whether or not the capability usage spans should be computed.
--}
-shouldComputeCapabilityUsageSpan :: FullConfig -> Bool
-shouldComputeCapabilityUsageSpan fullConfig =
-  C.processorEnabled (.traces) (.capabilityUsage) fullConfig
-    || C.processorEnabled (.metrics) (.capabilityUsage) fullConfig
-
-{- |
-Internal helper.
-Determine whether or not the thread state spans should be computed.
--}
-shouldComputeThreadStateSpan :: FullConfig -> Bool
-shouldComputeThreadStateSpan fullConfig =
-  C.processorEnabled (.traces) (.threadState) fullConfig
-    || shouldComputeCapabilityUsageSpan fullConfig
-
---------------------------------------------------------------------------------
--- processLogEvents
---------------------------------------------------------------------------------
-
-processLogEvents ::
-  (MonadIO m) =>
-  FullConfig ->
-  ProcessT m (Tick (WithStartTime Event)) (Tick (DList OL.LogRecord))
-processLogEvents fullConfig =
-  M.fanoutTick
-    [ processThreadLabel fullConfig
-    , processUserMarker fullConfig
-    , processUserMessage fullConfig
-    ]
-
---------------------------------------------------------------------------------
--- UserMessage
-
-processUserMessage :: FullConfig -> Process (Tick (WithStartTime Event)) (Tick (DList OL.LogRecord))
-processUserMessage fullConfig =
-  runIf (C.processorEnabled (.logs) (.userMessage) fullConfig) $
-    M.liftTick M.processUserMessageData
-      ~> M.liftTick (mapping (D.singleton . toLogRecord))
-      ~> M.batchByTicks (C.processorExportBatches (.logs) (.userMessage) fullConfig)
-
---------------------------------------------------------------------------------
--- UserMarker
-
-processUserMarker :: FullConfig -> Process (Tick (WithStartTime Event)) (Tick (DList OL.LogRecord))
-processUserMarker fullConfig =
-  runIf (C.processorEnabled (.logs) (.userMarker) fullConfig) $
-    M.liftTick M.processUserMarkerData
-      ~> M.liftTick (mapping (D.singleton . toLogRecord))
-      ~> M.batchByTicks (C.processorExportBatches (.logs) (.userMarker) fullConfig)
-
---------------------------------------------------------------------------------
--- ThreadLabel
-
-processThreadLabel :: FullConfig -> Process (Tick (WithStartTime Event)) (Tick (DList OL.LogRecord))
-processThreadLabel fullConfig =
-  runIf (C.processorEnabled (.logs) (.threadLabel) fullConfig) $
-    M.liftTick M.processThreadLabelData
-      ~> M.liftTick (mapping (D.singleton . toLogRecord))
-      ~> M.batchByTicks (C.processorExportBatches (.logs) (.threadLabel) fullConfig)
-
---------------------------------------------------------------------------------
--- processHeapEvents
---------------------------------------------------------------------------------
-
-processHeapEvents ::
-  (MonadIO m) =>
-  Logger m ->
-  Maybe HeapProfBreakdown ->
-  FullConfig ->
-  ProcessT m (Tick (WithStartTime Event)) (Tick (DList OM.Metric))
-processHeapEvents verbosity maybeHeapProfBreakdown fullConfig =
-  M.fanoutTick
-    [ processHeapAllocated fullConfig
-    , processBlocksSize fullConfig
-    , processHeapSize fullConfig
-    , processHeapLive fullConfig
-    , processMemReturn fullConfig
-    , processHeapProfSample verbosity maybeHeapProfBreakdown fullConfig
-    ]
-
---------------------------------------------------------------------------------
--- HeapAllocated
-
-processHeapAllocated :: FullConfig -> Process (Tick (WithStartTime Event)) (Tick (DList OM.Metric))
-processHeapAllocated =
-  runMetricProcessor
-    MetricProcessor
-      { metricProcessorProxy = Proxy @"heapAllocated"
-      , dataProcessor = M.processHeapAllocatedData
-      , aggregators = viaSum
-      , postProcessor = echo
-      , unit = "By"
-      , asMetric'Data =
-          asSum
-            [ OM.aggregationTemporality .~ OM.AGGREGATION_TEMPORALITY_DELTA
-            , OM.isMonotonic .~ True
-            ]
-      }
-
---------------------------------------------------------------------------------
--- HeapSize
-
-processHeapSize :: FullConfig -> Process (Tick (WithStartTime Event)) (Tick (DList OM.Metric))
-processHeapSize =
-  runMetricProcessor
-    MetricProcessor
-      { metricProcessorProxy = Proxy @"heapSize"
-      , dataProcessor = M.processHeapSizeData
-      , aggregators = viaLast
-      , postProcessor = echo
-      , unit = "By"
-      , asMetric'Data = asGauge
-      }
-
---------------------------------------------------------------------------------
--- BlocksSize
-
-processBlocksSize :: FullConfig -> Process (Tick (WithStartTime Event)) (Tick (DList OM.Metric))
-processBlocksSize =
-  runMetricProcessor
-    MetricProcessor
-      { metricProcessorProxy = Proxy @"blocksSize"
-      , dataProcessor = M.processBlocksSizeData
-      , aggregators = viaLast
-      , postProcessor = echo
-      , unit = "By"
-      , asMetric'Data = asGauge
-      }
-
---------------------------------------------------------------------------------
--- HeapLive
-
-processHeapLive :: FullConfig -> Process (Tick (WithStartTime Event)) (Tick (DList OM.Metric))
-processHeapLive =
-  runMetricProcessor
-    MetricProcessor
-      { metricProcessorProxy = Proxy @"heapLive"
-      , dataProcessor = M.processHeapLiveData
-      , aggregators = viaLast
-      , postProcessor = echo
-      , unit = "By"
-      , asMetric'Data = asGauge
-      }
-
---------------------------------------------------------------------------------
--- MemReturn
-
-processMemReturn :: FullConfig -> Process (Tick (WithStartTime Event)) (Tick (DList OM.Metric))
-processMemReturn fullConfig =
-  runIf (shouldComputeMemReturn fullConfig) $
-    M.liftTick M.processMemReturnData
-      ~> M.fanoutTick
-        [ runMetricProcessor
-            MetricProcessor
-              { metricProcessorProxy = Proxy @"memCurrent"
-              , dataProcessor = mapping (fmap (.current))
-              , aggregators = viaLast
-              , postProcessor = echo
-              , unit = "{mblock}"
-              , asMetric'Data = asGauge
-              }
-            fullConfig
-        , runMetricProcessor
-            MetricProcessor
-              { metricProcessorProxy = Proxy @"memNeeded"
-              , dataProcessor = mapping (fmap (.needed))
-              , aggregators = viaLast
-              , postProcessor = echo
-              , unit = "{mblock}"
-              , asMetric'Data = asGauge
-              }
-            fullConfig
-        , runMetricProcessor
-            MetricProcessor
-              { metricProcessorProxy = Proxy @"memReturned"
-              , dataProcessor = mapping (fmap (.returned))
-              , aggregators = viaLast
-              , postProcessor = echo
-              , unit = "{mblock}"
-              , asMetric'Data = asGauge
-              }
-            fullConfig
-        ]
-
-{- |
-Internal helper.
-Determine whether the MemReturn data should be computed.
--}
-shouldComputeMemReturn :: FullConfig -> Bool
-shouldComputeMemReturn fullConfig =
-  C.processorEnabled (.metrics) (.memCurrent) fullConfig
-    || C.processorEnabled (.metrics) (.memNeeded) fullConfig
-    || C.processorEnabled (.metrics) (.memReturned) fullConfig
-
---------------------------------------------------------------------------------
--- HeapProfSample
-
-processHeapProfSample ::
-  (MonadIO m) =>
-  Logger m ->
-  Maybe HeapProfBreakdown ->
-  FullConfig ->
-  ProcessT m (Tick (WithStartTime Event)) (Tick (DList OM.Metric))
-processHeapProfSample logger maybeHeapProfBreakdown =
-  runMetricProcessor
-    MetricProcessor
-      { metricProcessorProxy = Proxy @"heapProfSample"
-      , dataProcessor = M.processHeapProfSampleData logger maybeHeapProfBreakdown
-      , aggregators = viaLast
-      , postProcessor = mapping M.heapProfSamples ~> asParts
-      , unit = "By"
-      , asMetric'Data = asGauge
-      }
-
---------------------------------------------------------------------------------
--- Generic Metric Processor
-
-type MetricProcessor :: Symbol -> Type -> (Type -> Type) -> Type -> Type -> Type -> Type -> Type
-data MetricProcessor metricProcessor metricProcessorConfig m a b c d
-  = ( Monad m
-    , HasField metricProcessor C.Metrics (Maybe metricProcessorConfig)
-    , C.IsMetricProcessorConfig metricProcessorConfig
-    , IsNumberDataPoint'Value d
-    ) =>
-  MetricProcessor
-  { metricProcessorProxy :: !(Proxy metricProcessor)
-  -- ^ The metric's field name in `C.Metrics`.
-  , dataProcessor :: !(ProcessT m a b)
-  -- ^ The metric's data processor
-  , aggregators :: !(Aggregators b c)
-  -- ^ The metric's aggregator
-  , postProcessor :: !(Process c (Metric d))
-  -- ^ The metric's post processor
-  , unit :: !Text
-  -- ^ The metric's unit (in UCUM format).
-  , asMetric'Data :: !(Process [OM.NumberDataPoint] OM.Metric'Data)
-  -- ^ A process to wrap data points as `OM.Metric'Data`.
-  }
-
-{- |
-Internal helper.
-Run a `MetricProcessor`.
--}
-runMetricProcessor ::
-  forall metricProcessor metricProcessorConfig m a b c d.
-  (Default metricProcessorConfig) =>
-  MetricProcessor metricProcessor metricProcessorConfig m a b c d ->
-  -- | The full configuration.
-  FullConfig ->
-  ProcessT m (Tick a) (Tick (DList OM.Metric))
-runMetricProcessor MetricProcessor{..} fullConfig =
-  let metricProcessorConfig :: C.Metrics -> Maybe metricProcessorConfig
-      metricProcessorConfig = getField @metricProcessor
-   in runIf (C.processorEnabled (.metrics) metricProcessorConfig fullConfig) $
-        M.liftTick dataProcessor
-          ~> aggregate aggregators (C.processorAggregationBatches (.metrics) metricProcessorConfig fullConfig)
-          ~> M.liftTick postProcessor
-          ~> mapping (fmap (D.singleton . toNumberDataPoint))
-          ~> M.batchByTicks (C.processorExportBatches (.metrics) metricProcessorConfig fullConfig)
-          ~> M.liftTick
-            ( mapping D.toList
-                ~> asMetric'Data
-                ~> asMetricWith fullConfig metricProcessorConfig [OM.unit .~ unit]
-                ~> mapping D.singleton
-            )
-{-# INLINE runMetricProcessor #-}
-
---------------------------------------------------------------------------------
--- processProfileEvents
---------------------------------------------------------------------------------
-
-processProfileEvents ::
-  (MonadIO m) =>
-  Logger m ->
-  FullConfig ->
-  ProcessT m (Tick (WithStartTime Event)) (Tick (DList M.CallStackData))
-processProfileEvents verbosity config =
-  M.fanoutTick
-    [ processStackProfSample verbosity config
-    , processCostCentreProfSample verbosity config
-    ]
-
---------------------------------------------------------------------------------
--- StackProfSample
-
-processStackProfSample ::
-  (MonadIO m) =>
-  Logger m ->
-  FullConfig ->
-  ProcessT m (Tick (WithStartTime Event)) (Tick (DList M.CallStackData))
-processStackProfSample logger config = do
-  let
-    postProcessor = mapping M.stackProfSamples ~> asParts
-    dataProcessor = M.processStackProfSampleData logger
-  -- aggregators = viaLast
-  runIf (C.processorEnabled (.profiles) (.stackSample) config) $
-    M.liftTick dataProcessor
-      -- ~> aggregate aggregators (C.processorAggregationBatches (.profiles) (.stackSample) config)
-      ~> M.liftTick postProcessor
-      -- TODO: do something with the Metric value, right now it is completely unused
-      ~> M.liftTick (mapping (D.singleton . (.value)))
-      ~> M.batchByTicks (C.processorExportBatches (.profiles) (.stackSample) config)
-
-processCostCentreProfSample ::
-  (MonadIO m) =>
-  Logger m ->
-  FullConfig ->
-  ProcessT m (Tick (WithStartTime Event)) (Tick (DList M.CallStackData))
-processCostCentreProfSample logger config = do
-  let
-    postProcessor = mapping M.stackProfSamples ~> asParts
-    dataProcessor = M.processCostCentreProfSampleData logger
-  -- aggregators = viaLast
-  runIf (C.processorEnabled (.profiles) (.costCentreSample) config) $
-    M.liftTick dataProcessor
-      ~> M.liftTick postProcessor
-      ~> M.liftTick (mapping (D.singleton . (.value)))
-      ~> M.batchByTicks (C.processorExportBatches (.profiles) (.costCentreSample) config)
-
---------------------------------------------------------------------------------
--- Aggregation
---------------------------------------------------------------------------------
-
---------------------------------------------------------------------------------
--- Metric Aggregation
-
-data Aggregators a b = Aggregators
-  { nothing :: Process (Tick a) (Tick b)
-  , byBatches :: Int -> Process (Tick a) (Tick b)
-  }
-
-{- |
-Internal helper.
-Aggregate items based on the provided aggregators and aggregation strategy.
--}
-aggregate :: Aggregators a b -> Int -> Process (Tick a) (Tick b)
-aggregate Aggregators{..} aggregationBatches
-  | aggregationBatches >= 1 = byBatches aggregationBatches
-  | otherwise = nothing
-
-{- |
-Internal helper.
-Metric aggregators via the `Semigroup` instance for `Sum`.
--}
-viaSum :: forall a. (Num a) => Aggregators (Metric a) (Metric a)
-viaSum =
-  Aggregators
-    { nothing = echo
-    , byBatches = \ticks ->
-        -- TODO: Yield group sample counts as separate metric.
-        batchByTicksVia ticks (Proxy @(Metric (Sum a)))
-          ~> M.liftTick (mapping (fmap (.representative)) ~> asParts)
-    }
-
-{- |
-Internal helper.
-Metric aggregators via the `Semigroup` instance for `Last`.
--}
-viaLast :: forall a. (GroupBy a) => Aggregators a a
-viaLast =
-  Aggregators
-    { nothing = echo
-    , byBatches = \ticks ->
-        -- TODO: Yield group sample counts as separate metric.
-        batchByTicksVia ticks (Proxy @(Last a))
-          ~> M.liftTick (mapping (fmap (.representative)) ~> asParts)
-    }
-
-{- |
-Internal helper.
-This function aggregates items via a `Semigroup` instance and grouped by the `GroupBy` instance.
--}
-batchByTicksVia ::
-  forall a b.
-  (Coercible a b, GroupBy b, Semigroup b) =>
-  -- | The number of ticks per batch.
-  Int ->
-  Proxy b ->
-  Process (Tick a) (Tick [Group a])
-batchByTicksVia ticks (Proxy :: Proxy b) =
-  mapping (fmap DG.singleton . coerce @(Tick a) @(Tick b))
-    ~> M.batchByTicks @(GroupedBy b) ticks
-    ~> M.liftTick (mapping (coerce @[Group b] @[Group a] . DG.groups))
-
---------------------------------------------------------------------------------
--- Machines
+-- Instrumentation Scope
 --------------------------------------------------------------------------------
 
 -- 2025-09-22:
@@ -915,347 +388,3 @@ eventlogLiveScope =
     [ OC.name .~ eventlogLiveName
     , OC.version .~ eventlogLiveVersion
     ]
-
-asExportLogsServiceRequest :: Process [OL.ResourceLogs] OLS.ExportLogsServiceRequest
-asExportLogsServiceRequest = mapping $ (defMessage &) . (OL.resourceLogs .~)
-
-asExportMetricsServiceRequest :: Process [OM.ResourceMetrics] OMS.ExportMetricsServiceRequest
-asExportMetricsServiceRequest = mapping $ (defMessage &) . (OM.resourceMetrics .~)
-
-asExportTracesServiceRequest :: Process [OT.ResourceSpans] OTS.ExportTraceServiceRequest
-asExportTracesServiceRequest = mapping $ (defMessage &) . (OTS.resourceSpans .~)
-
-toResourceLogs :: OR.Resource -> [OL.ScopeLogs] -> Maybe OL.ResourceLogs
-toResourceLogs resource scopeLogs =
-  ifNonEmpty scopeLogs $
-    messageWith [OL.resource .~ resource, OL.scopeLogs .~ scopeLogs]
-
-toResourceMetrics :: OR.Resource -> [OM.ScopeMetrics] -> Maybe OM.ResourceMetrics
-toResourceMetrics resource scopeMetrics =
-  ifNonEmpty scopeMetrics $
-    messageWith [OL.resource .~ resource, OM.scopeMetrics .~ scopeMetrics]
-
-asExportProfileServiceRequest :: Process OP.ProfilesData OPS.ExportProfilesServiceRequest
-asExportProfileServiceRequest = mapping $ \profilesData ->
-  messageWith
-    [ OPS.resourceProfiles .~ profilesData ^. OPS.resourceProfiles
-    , OPS.dictionary .~ profilesData ^. OPS.dictionary
-    ]
-
-toResourceSpans :: OR.Resource -> [OT.ScopeSpans] -> Maybe OT.ResourceSpans
-toResourceSpans resource scopeSpans =
-  ifNonEmpty scopeSpans $
-    messageWith [OL.resource .~ resource, OT.scopeSpans .~ scopeSpans]
-
-toScopeLogs :: OC.InstrumentationScope -> [OL.LogRecord] -> Maybe OL.ScopeLogs
-toScopeLogs instrumentationScope logRecords =
-  ifNonEmpty logRecords $
-    messageWith [OL.scope .~ instrumentationScope, OL.logRecords .~ logRecords]
-
-toScopeMetrics :: OC.InstrumentationScope -> [OM.Metric] -> Maybe OM.ScopeMetrics
-toScopeMetrics instrumentationScope metrics =
-  ifNonEmpty metrics $
-    messageWith [OM.scope .~ instrumentationScope, OM.metrics .~ metrics]
-
-toScopeSpans :: OC.InstrumentationScope -> [OT.Span] -> Maybe OT.ScopeSpans
-toScopeSpans instrumentationScope spans =
-  ifNonEmpty spans $
-    messageWith [OT.scope .~ instrumentationScope, OT.spans .~ spans]
-
-ifNonEmpty :: [a] -> b -> Maybe b
-ifNonEmpty xs r = if null xs then Nothing else Just r
-
-asMetricWith ::
-  (Default a, HasField "description" a (Maybe Text), HasField "name" a (Maybe Text)) =>
-  FullConfig ->
-  (C.Metrics -> Maybe a) ->
-  [OM.Metric -> OM.Metric] ->
-  Process OM.Metric'Data OM.Metric
-asMetricWith fullConfig field mod =
-  asMetric $
-    [ OM.name .~ C.processorName (.metrics) field fullConfig
-    , maybe id (OM.description .~) $ C.processorDescription (.metrics) field fullConfig
-    ]
-      <> mod
-
-asMetric :: [OM.Metric -> OM.Metric] -> Process OM.Metric'Data OM.Metric
-asMetric mod = mapping $ toMetric mod
-
-toMetric :: [OM.Metric -> OM.Metric] -> OM.Metric'Data -> OM.Metric
-toMetric mod metric'data = messageWith ((OM.maybe'data' .~ Just metric'data) : mod)
-
-asGauge :: Process [OM.NumberDataPoint] OM.Metric'Data
-asGauge =
-  repeatedly $ do
-    await >>= \dataPoints ->
-      unless (null dataPoints) $
-        yield (toGauge dataPoints)
-
-toGauge :: [OM.NumberDataPoint] -> OM.Metric'Data
-toGauge dataPoints = OM.Metric'Gauge . messageWith $ [OM.dataPoints .~ dataPoints]
-
-asSum :: [OM.Sum -> OM.Sum] -> Process [OM.NumberDataPoint] OM.Metric'Data
-asSum mod =
-  repeatedly $
-    await >>= \dataPoints ->
-      unless (null dataPoints) $
-        yield (toSum mod dataPoints)
-
-toSum :: [OM.Sum -> OM.Sum] -> [OM.NumberDataPoint] -> OM.Metric'Data
-toSum mod dataPoints = OM.Metric'Sum . messageWith $ (OM.dataPoints .~ dataPoints) : mod
-
---------------------------------------------------------------------------------
--- Interpret data
---------------------------------------------------------------------------------
-
---------------------------------------------------------------------------------
--- Interpret logs
-
-class ToLogRecord v where
-  toLogRecord :: v -> OL.LogRecord
-
-instance ToLogRecord LogRecord where
-  toLogRecord :: LogRecord -> OL.LogRecord
-  toLogRecord i =
-    messageWith
-      [ OL.body .~ messageWith [OC.stringValue .~ i.body]
-      , OL.timeUnixNano .~ fromMaybe 0 i.maybeTimeUnixNano
-      , -- TODO: this could be set to the actual observed time in the processor.
-        OL.observedTimeUnixNano .~ fromMaybe 0 i.maybeTimeUnixNano
-      , OL.attributes .~ mapMaybe toMaybeKeyValue (toList i.attrs)
-      , OL.severityNumber .~ toSeverityNumber i.maybeSeverity
-      ]
-   where
-    toSeverityNumber :: Maybe Severity -> OL.SeverityNumber
-    toSeverityNumber = maybe OL.SEVERITY_NUMBER_UNSPECIFIED (toEnum . (.value) . DS.toSeverityNumber)
-
-instance ToLogRecord M.ThreadLabel where
-  toLogRecord :: M.ThreadLabel -> OL.LogRecord
-  toLogRecord i =
-    messageWith
-      [ OL.body .~ messageWith [OC.stringValue .~ i.threadlabel]
-      , OL.timeUnixNano .~ i.startTimeUnixNano
-      , -- TODO: this could be set to the actual observed time in the processor.
-        OL.observedTimeUnixNano .~ i.startTimeUnixNano
-      , OL.attributes
-          .~ mapMaybe
-            toMaybeKeyValue
-            [ "kind" ~= ("ThreadLabel" :: Text)
-            , "thread" ~= i.thread
-            ]
-      ]
-
---------------------------------------------------------------------------------
--- Interpret spans
-
-class AsSpan v where
-  -- | The `Key` type is used to index a `HashMap` in the default definition of `asSpan`.
-  type Key v
-
-  -- | The `toKey` function extracts a `Key` from the input value.
-  toKey ::
-    -- | The input value.
-    v ->
-    Key v
-
-  toSpan ::
-    -- | The configuration.
-    FullConfig ->
-    -- | The input value.
-    v ->
-    -- | The trace ID.
-    ByteString ->
-    -- | The span ID.
-    ByteString ->
-    OT.Span
-
-  -- | The `asSpan` machine processes values @v@ into OpenTelemetry spans `OT.Span`.
-  asSpan :: (MonadIO m) => FullConfig -> ProcessT m v OT.Span
-  default asSpan :: (MonadIO m, Hashable (Key v)) => FullConfig -> ProcessT m v OT.Span
-  asSpan fullConfig = construct $ go (mempty, Nothing)
-   where
-    -- go :: (HashMap (Key v) ByteString, Maybe StdGen) -> PlanT (Is v) OT.Span m Void
-    go (traceIds, maybeGen) = do
-      -- Ensure the StdGen is initialised
-      gen0 <- maybe (liftIO initStdGen) pure maybeGen
-      -- Receive the next value
-      i <- await
-      -- Ensure the next value has a trace ID
-      let ensureTraceId :: Maybe ByteString -> ((ByteString, StdGen), Maybe ByteString)
-          ensureTraceId = wrap . maybe (uniformByteString 16 gen0) (,gen0)
-           where
-            wrap out@(traceId, _gen) = (out, Just traceId)
-      let ((traceId, gen1), traceIds') = M.alterF ensureTraceId (toKey i) traceIds
-      -- Ensure the next value has a span ID
-      let (spanId, gen2) = uniformByteString 8 gen1
-      -- Yield a span
-      yield $ toSpan fullConfig i traceId spanId
-      -- Continue
-      go (traceIds', Just gen2)
-
---------------------------------------------------------------------------------
--- Interpret capability usage spans
-
-instance AsSpan CapabilityUsageSpan where
-  type Key CapabilityUsageSpan = Int
-
-  toKey :: CapabilityUsageSpan -> Int
-  toKey = (.cap)
-
-  toSpan :: FullConfig -> CapabilityUsageSpan -> ByteString -> ByteString -> OT.Span
-  toSpan fullConfig i traceId spanId =
-    messageWith
-      [ OT.traceId .~ traceId
-      , OT.spanId .~ spanId
-      , OT.name .~ C.processorName (.traces) (.capabilityUsage) fullConfig <> " " <> M.showCapabilityUserCategory user
-      , OT.kind .~ OT.Span'SPAN_KIND_INTERNAL
-      , OT.startTimeUnixNano .~ i.startTimeUnixNano
-      , OT.endTimeUnixNano .~ i.endTimeUnixNano
-      , OT.attributes
-          .~ mapMaybe
-            toMaybeKeyValue
-            [ "capability" ~= i.cap
-            , "user" ~= user
-            ]
-      , OT.status
-          .~ messageWith
-            [ OT.code .~ OT.Status'STATUS_CODE_OK
-            ]
-      ]
-   where
-    user = M.capabilityUser i
-
---------------------------------------------------------------------------------
--- Interpret thread state spans
-
-instance AsSpan ThreadStateSpan where
-  type Key ThreadStateSpan = ThreadId
-
-  toKey :: ThreadStateSpan -> ThreadId
-  toKey = (.thread)
-
-  toSpan :: FullConfig -> ThreadStateSpan -> ByteString -> ByteString -> OT.Span
-  toSpan fullConfig i traceId spanId =
-    messageWith
-      [ OT.traceId .~ traceId
-      , OT.spanId .~ spanId
-      , OT.name .~ C.processorName (.traces) (.threadState) fullConfig <> " " <> M.showThreadStateCategory i.threadState
-      , OT.kind .~ OT.Span'SPAN_KIND_INTERNAL
-      , OT.startTimeUnixNano .~ i.startTimeUnixNano
-      , OT.endTimeUnixNano .~ i.endTimeUnixNano
-      , OT.attributes
-          .~ mapMaybe
-            toMaybeKeyValue
-            [ "capability" ~= M.threadStateCap i.threadState
-            , "thread" ~= show i.thread
-            , "status" ~= (show <$> M.threadStateStatus i.threadState)
-            ]
-      , OT.status
-          .~ messageWith
-            [ OT.code .~ OT.Status'STATUS_CODE_OK
-            ]
-      ]
-
---------------------------------------------------------------------------------
--- Interpret metrics
-
-class IsNumberDataPoint'Value v where
-  toNumberDataPoint'Value :: v -> OM.NumberDataPoint'Value
-
-instance IsNumberDataPoint'Value Float where
-  toNumberDataPoint'Value :: Float -> OM.NumberDataPoint'Value
-  toNumberDataPoint'Value = OM.NumberDataPoint'AsDouble . realToFrac
-
-instance IsNumberDataPoint'Value Double where
-  toNumberDataPoint'Value :: Double -> OM.NumberDataPoint'Value
-  toNumberDataPoint'Value = OM.NumberDataPoint'AsDouble
-
-instance IsNumberDataPoint'Value Word8 where
-  toNumberDataPoint'Value :: Word8 -> OM.NumberDataPoint'Value
-  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral
-
-instance IsNumberDataPoint'Value Word16 where
-  toNumberDataPoint'Value :: Word16 -> OM.NumberDataPoint'Value
-  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral
-
-instance IsNumberDataPoint'Value Word32 where
-  toNumberDataPoint'Value :: Word32 -> OM.NumberDataPoint'Value
-  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral
-
--- | __Warning__: This instance may cause overflow.
-instance IsNumberDataPoint'Value Word64 where
-  toNumberDataPoint'Value :: Word64 -> OM.NumberDataPoint'Value
-  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral
-
--- | __Warning__: This instance may cause overflow.
-instance IsNumberDataPoint'Value Word where
-  toNumberDataPoint'Value :: Word -> OM.NumberDataPoint'Value
-  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral
-
-instance IsNumberDataPoint'Value Int8 where
-  toNumberDataPoint'Value :: Int8 -> OM.NumberDataPoint'Value
-  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral
-
-instance IsNumberDataPoint'Value Int16 where
-  toNumberDataPoint'Value :: Int16 -> OM.NumberDataPoint'Value
-  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral
-
-instance IsNumberDataPoint'Value Int32 where
-  toNumberDataPoint'Value :: Int32 -> OM.NumberDataPoint'Value
-  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral
-
-instance IsNumberDataPoint'Value Int64 where
-  toNumberDataPoint'Value :: Int64 -> OM.NumberDataPoint'Value
-  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt
-
-instance IsNumberDataPoint'Value Int where
-  toNumberDataPoint'Value :: Int -> OM.NumberDataPoint'Value
-  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral
-
-toNumberDataPoint :: (IsNumberDataPoint'Value v) => Metric v -> OM.NumberDataPoint
-toNumberDataPoint i =
-  messageWith
-    [ OM.maybe'value .~ Just (toNumberDataPoint'Value i.value)
-    , OM.timeUnixNano .~ fromMaybe 0 i.maybeTimeUnixNano
-    , OM.startTimeUnixNano .~ fromMaybe 0 i.maybeStartTimeUnixNano
-    , OM.attributes .~ mapMaybe toMaybeKeyValue (toList i.attrs)
-    ]
-
-toMaybeKeyValue :: Attr -> Maybe OC.KeyValue
-toMaybeKeyValue (k, v) =
-  toMaybeAnyValue v <&> \v ->
-    messageWith
-      [ OC.key .~ k
-      , OC.value .~ v
-      ]
-
-toMaybeAnyValue :: AttrValue -> Maybe OC.AnyValue
-toMaybeAnyValue = \case
-  AttrBool v -> Just $ messageWith [OC.boolValue .~ v]
-  AttrInt v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
-  AttrInt8 v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
-  AttrInt16 v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
-  AttrInt32 v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
-  AttrInt64 v -> Just $ messageWith [OC.intValue .~ v]
-  AttrWord v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
-  AttrWord8 v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
-  AttrWord16 v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
-  AttrWord32 v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
-  AttrWord64 v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
-  AttrDouble v -> Just $ messageWith [OC.doubleValue .~ v]
-  AttrText v -> Just $ messageWith [OC.stringValue .~ v]
-  AttrNull -> Nothing
-
---------------------------------------------------------------------------------
--- DSL for writing messages
-
--- | Construct a message with a list of modifications applied.
-messageWith :: (Message msg) => [msg -> msg] -> msg
-messageWith = foldr ($) defMessage
-
--------------------------------------------------------------------------------
--- Internal Helpers
--------------------------------------------------------------------------------
-
-runIf :: (Monad m) => Bool -> MachineT m k o -> MachineT m k o
-runIf b m = if b then m else stopped

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Common/Core.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Common/Core.hs
@@ -1,0 +1,68 @@
+{- |
+Module      : GHC.Eventlog.Live.Otelcol.Processor.Common.Core
+Description : Common utilities shared across telemetry data types.
+Stability   : experimental
+Portability : portable
+-}
+module GHC.Eventlog.Live.Otelcol.Processor.Common.Core (
+  messageWith,
+  runIf,
+  ifNonEmpty,
+  toMaybeKeyValue,
+)
+where
+
+import Data.Functor ((<&>))
+import Data.Machine (MachineT, stopped)
+import Data.ProtoLens (Message (..))
+import GHC.Eventlog.Live.Data.Attribute (Attr, AttrValue (..))
+import Lens.Family2 ((.~))
+import Proto.Opentelemetry.Proto.Common.V1.Common qualified as OC
+import Proto.Opentelemetry.Proto.Common.V1.Common_Fields qualified as OC
+
+-- | Construct a message with a list of modifications applied.
+messageWith :: (Message msg) => [msg -> msg] -> msg
+messageWith = foldr ($) defMessage
+
+-- | Run a machine if a boolean is @True@, otherwise stop.
+runIf :: (Monad m) => Bool -> MachineT m k o -> MachineT m k o
+runIf b m = if b then m else stopped
+
+-- | Return the second argument if the first argument is non-empty.
+ifNonEmpty :: [a] -> b -> Maybe b
+ifNonEmpty xs r = if null xs then Nothing else Just r
+
+--------------------------------------------------------------------------------
+-- Interpret attributes
+
+{- |
+Convert an `Attr` to an OTLP `OC.KeyValue`.
+-}
+toMaybeKeyValue :: Attr -> Maybe OC.KeyValue
+toMaybeKeyValue (k, v) =
+  toMaybeAnyValue v <&> \v' ->
+    messageWith
+      [ OC.key .~ k
+      , OC.value .~ v'
+      ]
+
+{- |
+Internal helper.
+Convert an `AttrValue` to an OTLP `OC.AnyValue`.
+-}
+toMaybeAnyValue :: AttrValue -> Maybe OC.AnyValue
+toMaybeAnyValue = \case
+  AttrBool v -> Just $ messageWith [OC.boolValue .~ v]
+  AttrInt v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
+  AttrInt8 v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
+  AttrInt16 v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
+  AttrInt32 v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
+  AttrInt64 v -> Just $ messageWith [OC.intValue .~ v]
+  AttrWord v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
+  AttrWord8 v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
+  AttrWord16 v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
+  AttrWord32 v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
+  AttrWord64 v -> Just $ messageWith [OC.intValue .~ fromIntegral v]
+  AttrDouble v -> Just $ messageWith [OC.doubleValue .~ v]
+  AttrText v -> Just $ messageWith [OC.stringValue .~ v]
+  AttrNull -> Nothing

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Common/Logs.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Common/Logs.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : GHC.Eventlog.Live.Otelcol.Processor.Common.Logs
+Description : Profile Processors for OTLP.
+Stability   : experimental
+Portability : portable
+-}
+module GHC.Eventlog.Live.Otelcol.Processor.Common.Logs (
+  ToLogRecord (..),
+  toExportLogsServiceRequest,
+  toResourceLogs,
+  toScopeLogs,
+)
+where
+
+import Data.Function ((&))
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.ProtoLens (Message (..))
+import Data.Text (Text)
+import GHC.Eventlog.Live.Data.Attribute ((~=))
+import GHC.Eventlog.Live.Data.LogRecord (LogRecord (..))
+import GHC.Eventlog.Live.Data.Severity (Severity)
+import GHC.Eventlog.Live.Data.Severity qualified as DS
+import GHC.Eventlog.Live.Machine.Analysis.Thread qualified as M
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Core (ifNonEmpty, messageWith, toMaybeKeyValue)
+import GHC.IsList (IsList (..))
+import Lens.Family2 ((.~))
+import Proto.Opentelemetry.Proto.Collector.Logs.V1.LogsService qualified as OLS
+import Proto.Opentelemetry.Proto.Common.V1.Common qualified as OC
+import Proto.Opentelemetry.Proto.Common.V1.Common_Fields qualified as OC
+import Proto.Opentelemetry.Proto.Logs.V1.Logs qualified as OL
+import Proto.Opentelemetry.Proto.Logs.V1.Logs_Fields qualified as OL
+import Proto.Opentelemetry.Proto.Resource.V1.Resource qualified as OR
+
+toExportLogsServiceRequest :: [OL.ResourceLogs] -> OLS.ExportLogsServiceRequest
+toExportLogsServiceRequest = (defMessage &) . (OL.resourceLogs .~)
+
+toResourceLogs :: OR.Resource -> [OL.ScopeLogs] -> Maybe OL.ResourceLogs
+toResourceLogs resource scopeLogs =
+  ifNonEmpty scopeLogs $
+    messageWith [OL.resource .~ resource, OL.scopeLogs .~ scopeLogs]
+
+toScopeLogs :: OC.InstrumentationScope -> [OL.LogRecord] -> Maybe OL.ScopeLogs
+toScopeLogs instrumentationScope logRecords =
+  ifNonEmpty logRecords $
+    messageWith [OL.scope .~ instrumentationScope, OL.logRecords .~ logRecords]
+
+--------------------------------------------------------------------------------
+-- Interpret logs
+
+class ToLogRecord v where
+  toLogRecord :: v -> OL.LogRecord
+
+instance ToLogRecord LogRecord where
+  toLogRecord :: LogRecord -> OL.LogRecord
+  toLogRecord i =
+    messageWith
+      [ OL.body .~ messageWith [OC.stringValue .~ i.body]
+      , OL.timeUnixNano .~ fromMaybe 0 i.maybeTimeUnixNano
+      , -- TODO: this could be set to the actual observed time in the processor.
+        OL.observedTimeUnixNano .~ fromMaybe 0 i.maybeTimeUnixNano
+      , OL.attributes .~ mapMaybe toMaybeKeyValue (toList i.attrs)
+      , OL.severityNumber .~ toSeverityNumber i.maybeSeverity
+      ]
+   where
+    toSeverityNumber :: Maybe Severity -> OL.SeverityNumber
+    toSeverityNumber = maybe OL.SEVERITY_NUMBER_UNSPECIFIED (toEnum . (.value) . DS.toSeverityNumber)
+
+instance ToLogRecord M.ThreadLabel where
+  toLogRecord :: M.ThreadLabel -> OL.LogRecord
+  toLogRecord i =
+    messageWith
+      [ OL.body .~ messageWith [OC.stringValue .~ i.threadlabel]
+      , OL.timeUnixNano .~ i.startTimeUnixNano
+      , -- TODO: this could be set to the actual observed time in the processor.
+        OL.observedTimeUnixNano .~ i.startTimeUnixNano
+      , OL.attributes
+          .~ mapMaybe
+            toMaybeKeyValue
+            [ "kind" ~= ("ThreadLabel" :: Text)
+            , "thread" ~= i.thread
+            ]
+      ]

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Common/Metrics.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Common/Metrics.hs
@@ -1,0 +1,288 @@
+{- |
+Module      : GHC.Eventlog.Live.Otelcol.Processor.Common.Metrics
+Description : Common utilities for metric processors.
+Stability   : experimental
+Portability : portable
+-}
+module GHC.Eventlog.Live.Otelcol.Processor.Common.Metrics (
+  MetricProcessor (..),
+  runMetricProcessor,
+  MetricAggregators (..),
+  viaSum,
+  viaLast,
+  asGauge,
+  asSum,
+  toScopeMetrics,
+  toResourceMetrics,
+  toExportMetricsServiceRequest,
+)
+where
+
+import Control.Monad (unless)
+import Data.Coerce (Coercible, coerce)
+import Data.DList (DList)
+import Data.DList qualified as D
+import Data.Default (Default)
+import Data.Function ((&))
+import Data.Int (Int16, Int32, Int64, Int8)
+import Data.Kind (Type)
+import Data.Machine (Process, ProcessT, asParts, await, echo, mapping, repeatedly, yield, (~>))
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.ProtoLens (Message (..))
+import Data.Proxy (Proxy (..))
+import Data.Semigroup (Last (..), Sum (..))
+import Data.Text (Text)
+import Data.Word (Word16, Word32, Word64, Word8)
+import GHC.Eventlog.Live.Data.Group (Group, GroupBy, GroupedBy)
+import GHC.Eventlog.Live.Data.Group qualified as DG
+import GHC.Eventlog.Live.Data.Metric (Metric (..))
+import GHC.Eventlog.Live.Machine.Core (Tick)
+import GHC.Eventlog.Live.Machine.Core qualified as M
+import GHC.Eventlog.Live.Otelcol.Config qualified as C
+import GHC.Eventlog.Live.Otelcol.Config.Types (FullConfig)
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Core (ifNonEmpty, messageWith, runIf, toMaybeKeyValue)
+import GHC.IsList (IsList (..))
+import GHC.Records (HasField (..))
+import GHC.TypeLits (Symbol)
+import Lens.Family2 ((.~))
+import Proto.Opentelemetry.Proto.Collector.Metrics.V1.MetricsService qualified as OMS
+import Proto.Opentelemetry.Proto.Common.V1.Common qualified as OC
+import Proto.Opentelemetry.Proto.Metrics.V1.Metrics qualified as OM
+import Proto.Opentelemetry.Proto.Metrics.V1.Metrics_Fields qualified as OM
+import Proto.Opentelemetry.Proto.Resource.V1.Resource qualified as OR
+
+--------------------------------------------------------------------------------
+-- Generic Metric Processor
+
+type MetricProcessor :: Symbol -> Type -> (Type -> Type) -> Type -> Type -> Type -> Type -> Type
+data MetricProcessor metricProcessor metricProcessorConfig m a b c d
+  = ( Monad m
+    , HasField metricProcessor C.Metrics (Maybe metricProcessorConfig)
+    , C.IsMetricProcessorConfig metricProcessorConfig
+    , IsNumberDataPoint'Value d
+    ) =>
+  MetricProcessor
+  { metricProcessorProxy :: !(Proxy metricProcessor)
+  -- ^ The metric's field name in `C.Metrics`.
+  , dataProcessor :: !(ProcessT m a b)
+  -- ^ The metric's data processor
+  , aggregators :: !(MetricAggregators b c)
+  -- ^ The metric's aggregator
+  , postProcessor :: !(ProcessT m c (Metric d))
+  -- ^ The metric's post processor
+  , unit :: !Text
+  -- ^ The metric's unit (in UCUM format).
+  , asMetric'Data :: !(ProcessT m [OM.NumberDataPoint] OM.Metric'Data)
+  -- ^ A process to wrap data points as `OM.Metric'Data`.
+  }
+
+{- |
+Internal helper.
+Run a `MetricProcessor`.
+-}
+runMetricProcessor ::
+  forall metricProcessor metricProcessorConfig m a b c d.
+  (Default metricProcessorConfig) =>
+  MetricProcessor metricProcessor metricProcessorConfig m a b c d ->
+  -- | The full configuration.
+  FullConfig ->
+  ProcessT m (Tick a) (Tick (DList OM.Metric))
+runMetricProcessor MetricProcessor{..} fullConfig =
+  let metricProcessorConfig :: C.Metrics -> Maybe metricProcessorConfig
+      metricProcessorConfig = getField @metricProcessor
+   in runIf (C.processorEnabled (.metrics) metricProcessorConfig fullConfig) $
+        M.liftTick dataProcessor
+          ~> aggregate aggregators (C.processorAggregationBatches (.metrics) metricProcessorConfig fullConfig)
+          ~> M.liftTick postProcessor
+          ~> mapping (fmap (D.singleton . toNumberDataPoint))
+          ~> M.batchByTicks (C.processorExportBatches (.metrics) metricProcessorConfig fullConfig)
+          ~> M.liftTick
+            ( mapping D.toList
+                ~> asMetric'Data
+                ~> asMetricWith fullConfig metricProcessorConfig [OM.unit .~ unit]
+                ~> mapping D.singleton
+            )
+{-# INLINE runMetricProcessor #-}
+
+asMetricWith ::
+  (Default a, HasField "description" a (Maybe Text), HasField "name" a (Maybe Text)) =>
+  FullConfig ->
+  (C.Metrics -> Maybe a) ->
+  [OM.Metric -> OM.Metric] ->
+  Process OM.Metric'Data OM.Metric
+asMetricWith fullConfig field f =
+  asMetric $
+    [ OM.name .~ C.processorName (.metrics) field fullConfig
+    , maybe id (OM.description .~) $ C.processorDescription (.metrics) field fullConfig
+    ]
+      <> f
+
+asMetric :: [OM.Metric -> OM.Metric] -> Process OM.Metric'Data OM.Metric
+asMetric f = mapping $ toMetric f
+
+toMetric :: [OM.Metric -> OM.Metric] -> OM.Metric'Data -> OM.Metric
+toMetric f metric'data = messageWith ((OM.maybe'data' .~ Just metric'data) : f)
+
+toExportMetricsServiceRequest :: [OM.ResourceMetrics] -> OMS.ExportMetricsServiceRequest
+toExportMetricsServiceRequest = (defMessage &) . (OM.resourceMetrics .~)
+
+toResourceMetrics :: OR.Resource -> [OM.ScopeMetrics] -> Maybe OM.ResourceMetrics
+toResourceMetrics resource scopeMetrics =
+  ifNonEmpty scopeMetrics $
+    messageWith [OM.resource .~ resource, OM.scopeMetrics .~ scopeMetrics]
+
+toScopeMetrics :: OC.InstrumentationScope -> [OM.Metric] -> Maybe OM.ScopeMetrics
+toScopeMetrics instrumentationScope metrics =
+  ifNonEmpty metrics $
+    messageWith [OM.scope .~ instrumentationScope, OM.metrics .~ metrics]
+
+asGauge :: Process [OM.NumberDataPoint] OM.Metric'Data
+asGauge =
+  repeatedly $ do
+    await >>= \dataPoints ->
+      unless (null dataPoints) $
+        yield (toGauge dataPoints)
+
+toGauge :: [OM.NumberDataPoint] -> OM.Metric'Data
+toGauge dataPoints = OM.Metric'Gauge . messageWith $ [OM.dataPoints .~ dataPoints]
+
+asSum :: [OM.Sum -> OM.Sum] -> Process [OM.NumberDataPoint] OM.Metric'Data
+asSum f =
+  repeatedly $
+    await >>= \dataPoints ->
+      unless (null dataPoints) $
+        yield (toSum f dataPoints)
+
+toSum :: [OM.Sum -> OM.Sum] -> [OM.NumberDataPoint] -> OM.Metric'Data
+toSum f dataPoints = OM.Metric'Sum . messageWith $ (OM.dataPoints .~ dataPoints) : f
+
+--------------------------------------------------------------------------------
+-- Metric Aggregation
+
+data MetricAggregators a b = MetricAggregators
+  { nothing :: Process (Tick a) (Tick b)
+  , byBatches :: Int -> Process (Tick a) (Tick b)
+  }
+
+{- |
+Internal helper.
+Aggregate items based on the provided aggregators and aggregation strategy.
+-}
+aggregate :: MetricAggregators a b -> Int -> Process (Tick a) (Tick b)
+aggregate MetricAggregators{..} aggregationBatches
+  | aggregationBatches >= 1 = byBatches aggregationBatches
+  | otherwise = nothing
+
+{- |
+Internal helper.
+Metric aggregators via the `Semigroup` instance for `Sum`.
+-}
+viaSum :: forall a. (Num a) => MetricAggregators (Metric a) (Metric a)
+viaSum =
+  MetricAggregators
+    { nothing = echo
+    , byBatches = \ticks ->
+        -- TODO: Yield group sample counts as separate metric.
+        batchByTicksVia ticks (Proxy @(Metric (Sum a)))
+          ~> M.liftTick (mapping (fmap (.representative)) ~> asParts)
+    }
+
+{- |
+Internal helper.
+Metric aggregators via the `Semigroup` instance for `Last`.
+-}
+viaLast :: forall a. (GroupBy a) => MetricAggregators a a
+viaLast =
+  MetricAggregators
+    { nothing = echo
+    , byBatches = \ticks ->
+        -- TODO: Yield group sample counts as separate metric.
+        batchByTicksVia ticks (Proxy @(Last a))
+          ~> M.liftTick (mapping (fmap (.representative)) ~> asParts)
+    }
+
+{- |
+Internal helper.
+This function aggregates items via a `Semigroup` instance and grouped by the `GroupBy` instance.
+-}
+batchByTicksVia ::
+  forall a b.
+  (Coercible a b, GroupBy b, Semigroup b) =>
+  -- | The number of ticks per batch.
+  Int ->
+  Proxy b ->
+  Process (Tick a) (Tick [Group a])
+batchByTicksVia ticks (Proxy :: Proxy b) =
+  mapping (fmap DG.singleton . coerce @(Tick a) @(Tick b))
+    ~> M.batchByTicks @(GroupedBy b) ticks
+    ~> M.liftTick (mapping (coerce @[Group b] @[Group a] . DG.groups))
+
+{- |
+Internal helper.
+Convert a metric datapoint to an `OM.NumberDataPoint`.
+-}
+toNumberDataPoint :: (IsNumberDataPoint'Value v) => Metric v -> OM.NumberDataPoint
+toNumberDataPoint i =
+  messageWith
+    [ OM.maybe'value .~ Just (toNumberDataPoint'Value i.value)
+    , OM.timeUnixNano .~ fromMaybe 0 i.maybeTimeUnixNano
+    , OM.startTimeUnixNano .~ fromMaybe 0 i.maybeStartTimeUnixNano
+    , OM.attributes .~ mapMaybe toMaybeKeyValue (toList i.attrs)
+    ]
+
+{- |
+Internal helper.
+Class of types that can be converted to `OM.NumberDataPoint'Value` values.
+-}
+class IsNumberDataPoint'Value v where
+  toNumberDataPoint'Value :: v -> OM.NumberDataPoint'Value
+
+instance IsNumberDataPoint'Value Float where
+  toNumberDataPoint'Value :: Float -> OM.NumberDataPoint'Value
+  toNumberDataPoint'Value = OM.NumberDataPoint'AsDouble . realToFrac
+
+instance IsNumberDataPoint'Value Double where
+  toNumberDataPoint'Value :: Double -> OM.NumberDataPoint'Value
+  toNumberDataPoint'Value = OM.NumberDataPoint'AsDouble
+
+instance IsNumberDataPoint'Value Word8 where
+  toNumberDataPoint'Value :: Word8 -> OM.NumberDataPoint'Value
+  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral
+
+instance IsNumberDataPoint'Value Word16 where
+  toNumberDataPoint'Value :: Word16 -> OM.NumberDataPoint'Value
+  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral
+
+instance IsNumberDataPoint'Value Word32 where
+  toNumberDataPoint'Value :: Word32 -> OM.NumberDataPoint'Value
+  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral
+
+-- | __Warning__: This instance may cause overflow.
+instance IsNumberDataPoint'Value Word64 where
+  toNumberDataPoint'Value :: Word64 -> OM.NumberDataPoint'Value
+  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral
+
+-- | __Warning__: This instance may cause overflow.
+instance IsNumberDataPoint'Value Word where
+  toNumberDataPoint'Value :: Word -> OM.NumberDataPoint'Value
+  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral
+
+instance IsNumberDataPoint'Value Int8 where
+  toNumberDataPoint'Value :: Int8 -> OM.NumberDataPoint'Value
+  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral
+
+instance IsNumberDataPoint'Value Int16 where
+  toNumberDataPoint'Value :: Int16 -> OM.NumberDataPoint'Value
+  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral
+
+instance IsNumberDataPoint'Value Int32 where
+  toNumberDataPoint'Value :: Int32 -> OM.NumberDataPoint'Value
+  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral
+
+instance IsNumberDataPoint'Value Int64 where
+  toNumberDataPoint'Value :: Int64 -> OM.NumberDataPoint'Value
+  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt
+
+instance IsNumberDataPoint'Value Int where
+  toNumberDataPoint'Value :: Int -> OM.NumberDataPoint'Value
+  toNumberDataPoint'Value = OM.NumberDataPoint'AsInt . fromIntegral

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Common/Profiles.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Common/Profiles.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 {- |
-Module      : GHC.Eventlog.Live.Otelcol.Processor.Profiles.Dictionary
+Module      : GHC.Eventlog.Live.Otelcol.Processor.Common.Profiles
 Description : Abstraction over ProfilesDictionary for the OTLP protocol.
 Stability   : experimental
 Portability : portable
 -}
-module GHC.Eventlog.Live.Otelcol.Processor.Profiles.Dictionary (
+module GHC.Eventlog.Live.Otelcol.Processor.Common.Profiles (
+  toExportProfileServiceRequest,
+
   -- * Dictionary for deduplication logic of common values
   ProfileDictionary,
   emptyProfileDictionary,
@@ -28,16 +30,26 @@ where
 
 import Control.Monad.Trans.State.Strict (StateT)
 import Control.Monad.Trans.State.Strict qualified as State
-import Data.Int
+import Data.Int (Int32)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.ProtoLens
+import Data.ProtoLens (Message (..))
 import Data.Text (Text)
-import GHC.Generics
-import Lens.Family2
-import Lens.Family2.Unchecked
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Core (messageWith)
+import GHC.Generics (Generic)
+import Lens.Family2 (Lens', (&), (.~), (^.))
+import Lens.Family2.Unchecked (lens)
+import Proto.Opentelemetry.Proto.Collector.Profiles.V1development.ProfilesService qualified as OPS
+import Proto.Opentelemetry.Proto.Collector.Profiles.V1development.ProfilesService_Fields qualified as OPS
 import Proto.Opentelemetry.Proto.Profiles.V1development.Profiles qualified as OP
 import Proto.Opentelemetry.Proto.Profiles.V1development.Profiles_Fields qualified as OP
+
+toExportProfileServiceRequest :: OP.ProfilesData -> OPS.ExportProfilesServiceRequest
+toExportProfileServiceRequest profilesData =
+  messageWith
+    [ OPS.resourceProfiles .~ profilesData ^. OPS.resourceProfiles
+    , OPS.dictionary .~ profilesData ^. OPS.dictionary
+    ]
 
 type SymbolIndex = Int32
 
@@ -74,21 +86,15 @@ data ProfileDictionary = ProfileDictionary
 
 toProfilesDictionary :: ProfileDictionary -> OP.ProfilesDictionary
 toProfilesDictionary st =
-  defMessage
-    & OP.locationTable
-      .~ locationTableList st
-    & OP.functionTable
-      .~ functionTableList st
-    & OP.stringTable
-      .~ stringTableList st
-    & OP.mappingTable
-      .~ mappingTableList st
-    & OP.linkTable
-      .~ linkTableList st
-    & OP.attributeTable
-      .~ attributeTableList st
-    & OP.stackTable
-      .~ stackTableList st
+  messageWith
+    [ OP.locationTable .~ locationTableList st
+    , OP.functionTable .~ functionTableList st
+    , OP.stringTable .~ stringTableList st
+    , OP.mappingTable .~ mappingTableList st
+    , OP.linkTable .~ linkTableList st
+    , OP.attributeTable .~ attributeTableList st
+    , OP.stackTable .~ stackTableList st
+    ]
 
 emptyProfileDictionary :: ProfileDictionary
 emptyProfileDictionary =

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Common/Traces.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Common/Traces.hs
@@ -1,0 +1,167 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : GHC.Eventlog.Live.Otelcol.Processor.Common.Traces
+Description : Profile Processors for OTLP.
+Stability   : experimental
+Portability : portable
+-}
+module GHC.Eventlog.Live.Otelcol.Processor.Common.Traces (
+  asSpan,
+  ToSpan (..),
+  toExportTracesServiceRequest,
+  toResourceSpans,
+  toScopeSpans,
+)
+where
+
+import Control.Monad.IO.Class (MonadIO (..))
+import Data.ByteString (ByteString)
+import Data.Function ((&))
+import Data.HashMap.Strict qualified as HM
+import Data.Hashable (Hashable)
+import Data.Machine (ProcessT, await, construct, yield)
+import Data.Maybe (mapMaybe)
+import Data.ProtoLens (Message (..))
+import GHC.Eventlog.Live.Data.Attribute ((~=))
+import GHC.Eventlog.Live.Machine.Analysis.Capability (CapabilityUsageSpan)
+import GHC.Eventlog.Live.Machine.Analysis.Capability qualified as M
+import GHC.Eventlog.Live.Machine.Analysis.Thread (ThreadStateSpan (..))
+import GHC.Eventlog.Live.Machine.Analysis.Thread qualified as M
+import GHC.Eventlog.Live.Otelcol.Config qualified as C
+import GHC.Eventlog.Live.Otelcol.Config.Types (FullConfig)
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Core (ifNonEmpty, messageWith, toMaybeKeyValue)
+import GHC.RTS.Events (ThreadId)
+import Lens.Family2 ((.~))
+import Proto.Opentelemetry.Proto.Collector.Trace.V1.TraceService qualified as OTS
+import Proto.Opentelemetry.Proto.Common.V1.Common qualified as OC
+import Proto.Opentelemetry.Proto.Logs.V1.Logs_Fields qualified as OL
+import Proto.Opentelemetry.Proto.Resource.V1.Resource qualified as OR
+import Proto.Opentelemetry.Proto.Trace.V1.Trace qualified as OT
+import Proto.Opentelemetry.Proto.Trace.V1.Trace_Fields qualified as OT
+import Proto.Opentelemetry.Proto.Trace.V1.Trace_Fields qualified as OTS
+import System.Random (StdGen, initStdGen)
+import System.Random.Compat (uniformByteString)
+
+toExportTracesServiceRequest :: [OT.ResourceSpans] -> OTS.ExportTraceServiceRequest
+toExportTracesServiceRequest = (defMessage &) . (OTS.resourceSpans .~)
+
+toResourceSpans :: OR.Resource -> [OT.ScopeSpans] -> Maybe OT.ResourceSpans
+toResourceSpans resource scopeSpans =
+  ifNonEmpty scopeSpans $
+    messageWith [OL.resource .~ resource, OT.scopeSpans .~ scopeSpans]
+
+toScopeSpans :: OC.InstrumentationScope -> [OT.Span] -> Maybe OT.ScopeSpans
+toScopeSpans instrumentationScope spans =
+  ifNonEmpty spans $
+    messageWith [OT.scope .~ instrumentationScope, OT.spans .~ spans]
+
+--------------------------------------------------------------------------------
+-- Interpret spans
+
+-- | The `asSpan` machine processes values @v@ into OpenTelemetry spans `OT.Span`.
+asSpan :: (ToSpan v, MonadIO m, Hashable (Key v)) => FullConfig -> ProcessT m v OT.Span
+asSpan fullConfig = construct $ go (mempty, Nothing)
+ where
+  -- go :: (HashMap (Key v) ByteString, Maybe StdGen) -> PlanT (Is v) OT.Span m Void
+  go (traceIds, maybeGen) = do
+    -- Ensure the StdGen is initialised
+    gen0 <- maybe (liftIO initStdGen) pure maybeGen
+    -- Receive the next value
+    i <- await
+    -- Ensure the next value has a trace ID
+    let ensureTraceId :: Maybe ByteString -> ((ByteString, StdGen), Maybe ByteString)
+        ensureTraceId = wrap . maybe (uniformByteString 16 gen0) (,gen0)
+         where
+          wrap out@(traceId, _gen) = (out, Just traceId)
+    let ((traceId, gen1), traceIds') = HM.alterF ensureTraceId (toKey i) traceIds
+    -- Ensure the next value has a span ID
+    let (spanId, gen2) = uniformByteString 8 gen1
+    -- Yield a span
+    yield $ toSpan fullConfig i traceId spanId
+    -- Continue
+    go (traceIds', Just gen2)
+
+class ToSpan v where
+  -- | The `Key` type is used to index a `HashMap` in the default definition of `asSpan`.
+  type Key v
+
+  -- | The `toKey` function extracts a `Key` from the input value.
+  toKey ::
+    -- | The input value.
+    v ->
+    Key v
+
+  toSpan ::
+    -- | The configuration.
+    FullConfig ->
+    -- | The input value.
+    v ->
+    -- | The trace ID.
+    ByteString ->
+    -- | The span ID.
+    ByteString ->
+    OT.Span
+
+--------------------------------------------------------------------------------
+-- Interpret capability usage spans
+
+instance ToSpan CapabilityUsageSpan where
+  type Key CapabilityUsageSpan = Int
+
+  toKey :: CapabilityUsageSpan -> Int
+  toKey = (.cap)
+
+  toSpan :: FullConfig -> CapabilityUsageSpan -> ByteString -> ByteString -> OT.Span
+  toSpan fullConfig i traceId spanId =
+    messageWith
+      [ OT.traceId .~ traceId
+      , OT.spanId .~ spanId
+      , OT.name .~ C.processorName (.traces) (.capabilityUsage) fullConfig <> " " <> M.showCapabilityUserCategory user
+      , OT.kind .~ OT.Span'SPAN_KIND_INTERNAL
+      , OT.startTimeUnixNano .~ i.startTimeUnixNano
+      , OT.endTimeUnixNano .~ i.endTimeUnixNano
+      , OT.attributes
+          .~ mapMaybe
+            toMaybeKeyValue
+            [ "capability" ~= i.cap
+            , "user" ~= user
+            ]
+      , OT.status
+          .~ messageWith
+            [ OT.code .~ OT.Status'STATUS_CODE_OK
+            ]
+      ]
+   where
+    user = M.capabilityUser i
+
+--------------------------------------------------------------------------------
+-- Interpret thread state spans
+
+instance ToSpan ThreadStateSpan where
+  type Key ThreadStateSpan = ThreadId
+
+  toKey :: ThreadStateSpan -> ThreadId
+  toKey = (.thread)
+
+  toSpan :: FullConfig -> ThreadStateSpan -> ByteString -> ByteString -> OT.Span
+  toSpan fullConfig i traceId spanId =
+    messageWith
+      [ OT.traceId .~ traceId
+      , OT.spanId .~ spanId
+      , OT.name .~ C.processorName (.traces) (.threadState) fullConfig <> " " <> M.showThreadStateCategory i.threadState
+      , OT.kind .~ OT.Span'SPAN_KIND_INTERNAL
+      , OT.startTimeUnixNano .~ i.startTimeUnixNano
+      , OT.endTimeUnixNano .~ i.endTimeUnixNano
+      , OT.attributes
+          .~ mapMaybe
+            toMaybeKeyValue
+            [ "capability" ~= M.threadStateCap i.threadState
+            , "thread" ~= show i.thread
+            , "status" ~= (show <$> M.threadStateStatus i.threadState)
+            ]
+      , OT.status
+          .~ messageWith
+            [ OT.code .~ OT.Status'STATUS_CODE_OK
+            ]
+      ]

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Heap.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Heap.hs
@@ -1,0 +1,185 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : GHC.Eventlog.Live.Otelcol.Processor.Heap
+Description : Heap Event Processors for OTLP.
+Stability   : experimental
+Portability : portable
+-}
+module GHC.Eventlog.Live.Otelcol.Processor.Heap (
+  processHeapEvents,
+)
+where
+
+import Control.Monad.IO.Class (MonadIO (..))
+import Data.DList (DList)
+import Data.Machine (Process, ProcessT, asParts, echo, mapping, (~>))
+import Data.Proxy (Proxy (..))
+import GHC.Eventlog.Live.Logger (Logger)
+import GHC.Eventlog.Live.Machine.Analysis.Heap (MemReturnData (..))
+import GHC.Eventlog.Live.Machine.Analysis.Heap qualified as M
+import GHC.Eventlog.Live.Machine.Core (Tick)
+import GHC.Eventlog.Live.Machine.Core qualified as M
+import GHC.Eventlog.Live.Machine.WithStartTime (WithStartTime (..))
+import GHC.Eventlog.Live.Otelcol.Config qualified as C
+import GHC.Eventlog.Live.Otelcol.Config.Types (FullConfig (..))
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Core (runIf)
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Metrics (MetricProcessor (..), asGauge, asSum, runMetricProcessor, viaLast, viaSum)
+import GHC.RTS.Events (Event (..), HeapProfBreakdown (..))
+import Lens.Family2 ((.~))
+import Proto.Opentelemetry.Proto.Metrics.V1.Metrics qualified as OM
+import Proto.Opentelemetry.Proto.Metrics.V1.Metrics_Fields qualified as OM
+
+--------------------------------------------------------------------------------
+-- processHeapEvents
+--------------------------------------------------------------------------------
+
+processHeapEvents ::
+  (MonadIO m) =>
+  Logger m ->
+  Maybe HeapProfBreakdown ->
+  FullConfig ->
+  ProcessT m (Tick (WithStartTime Event)) (Tick (DList OM.Metric))
+processHeapEvents verbosity maybeHeapProfBreakdown fullConfig =
+  M.fanoutTick
+    [ processHeapAllocated fullConfig
+    , processBlocksSize fullConfig
+    , processHeapSize fullConfig
+    , processHeapLive fullConfig
+    , processMemReturn fullConfig
+    , processHeapProfSample verbosity maybeHeapProfBreakdown fullConfig
+    ]
+
+--------------------------------------------------------------------------------
+-- HeapAllocated
+
+processHeapAllocated :: FullConfig -> Process (Tick (WithStartTime Event)) (Tick (DList OM.Metric))
+processHeapAllocated =
+  runMetricProcessor
+    MetricProcessor
+      { metricProcessorProxy = Proxy @"heapAllocated"
+      , dataProcessor = M.processHeapAllocatedData
+      , aggregators = viaSum
+      , postProcessor = echo
+      , unit = "By"
+      , asMetric'Data =
+          asSum
+            [ OM.aggregationTemporality .~ OM.AGGREGATION_TEMPORALITY_DELTA
+            , OM.isMonotonic .~ True
+            ]
+      }
+
+--------------------------------------------------------------------------------
+-- HeapSize
+
+processHeapSize :: FullConfig -> Process (Tick (WithStartTime Event)) (Tick (DList OM.Metric))
+processHeapSize =
+  runMetricProcessor
+    MetricProcessor
+      { metricProcessorProxy = Proxy @"heapSize"
+      , dataProcessor = M.processHeapSizeData
+      , aggregators = viaLast
+      , postProcessor = echo
+      , unit = "By"
+      , asMetric'Data = asGauge
+      }
+
+--------------------------------------------------------------------------------
+-- BlocksSize
+
+processBlocksSize :: FullConfig -> Process (Tick (WithStartTime Event)) (Tick (DList OM.Metric))
+processBlocksSize =
+  runMetricProcessor
+    MetricProcessor
+      { metricProcessorProxy = Proxy @"blocksSize"
+      , dataProcessor = M.processBlocksSizeData
+      , aggregators = viaLast
+      , postProcessor = echo
+      , unit = "By"
+      , asMetric'Data = asGauge
+      }
+
+--------------------------------------------------------------------------------
+-- HeapLive
+
+processHeapLive :: FullConfig -> Process (Tick (WithStartTime Event)) (Tick (DList OM.Metric))
+processHeapLive =
+  runMetricProcessor
+    MetricProcessor
+      { metricProcessorProxy = Proxy @"heapLive"
+      , dataProcessor = M.processHeapLiveData
+      , aggregators = viaLast
+      , postProcessor = echo
+      , unit = "By"
+      , asMetric'Data = asGauge
+      }
+
+--------------------------------------------------------------------------------
+-- MemReturn
+
+processMemReturn :: FullConfig -> Process (Tick (WithStartTime Event)) (Tick (DList OM.Metric))
+processMemReturn fullConfig =
+  runIf (shouldComputeMemReturn fullConfig) $
+    M.liftTick M.processMemReturnData
+      ~> M.fanoutTick
+        [ runMetricProcessor
+            MetricProcessor
+              { metricProcessorProxy = Proxy @"memCurrent"
+              , dataProcessor = mapping (fmap (.current))
+              , aggregators = viaLast
+              , postProcessor = echo
+              , unit = "{mblock}"
+              , asMetric'Data = asGauge
+              }
+            fullConfig
+        , runMetricProcessor
+            MetricProcessor
+              { metricProcessorProxy = Proxy @"memNeeded"
+              , dataProcessor = mapping (fmap (.needed))
+              , aggregators = viaLast
+              , postProcessor = echo
+              , unit = "{mblock}"
+              , asMetric'Data = asGauge
+              }
+            fullConfig
+        , runMetricProcessor
+            MetricProcessor
+              { metricProcessorProxy = Proxy @"memReturned"
+              , dataProcessor = mapping (fmap (.returned))
+              , aggregators = viaLast
+              , postProcessor = echo
+              , unit = "{mblock}"
+              , asMetric'Data = asGauge
+              }
+            fullConfig
+        ]
+
+{- |
+Internal helper.
+Determine whether the MemReturn data should be computed.
+-}
+shouldComputeMemReturn :: FullConfig -> Bool
+shouldComputeMemReturn fullConfig =
+  C.processorEnabled (.metrics) (.memCurrent) fullConfig
+    || C.processorEnabled (.metrics) (.memNeeded) fullConfig
+    || C.processorEnabled (.metrics) (.memReturned) fullConfig
+
+--------------------------------------------------------------------------------
+-- HeapProfSample
+
+processHeapProfSample ::
+  (MonadIO m) =>
+  Logger m ->
+  Maybe HeapProfBreakdown ->
+  FullConfig ->
+  ProcessT m (Tick (WithStartTime Event)) (Tick (DList OM.Metric))
+processHeapProfSample logger maybeHeapProfBreakdown =
+  runMetricProcessor
+    MetricProcessor
+      { metricProcessorProxy = Proxy @"heapProfSample"
+      , dataProcessor = M.processHeapProfSampleData logger maybeHeapProfBreakdown
+      , aggregators = viaLast
+      , postProcessor = mapping M.heapProfSamples ~> asParts
+      , unit = "By"
+      , asMetric'Data = asGauge
+      }

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Logs.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Logs.hs
@@ -1,0 +1,71 @@
+{- |
+Module      : GHC.Eventlog.Live.Otelcol.Processor.Logs
+Description : Log Processors for OTLP.
+Stability   : experimental
+Portability : portable
+-}
+module GHC.Eventlog.Live.Otelcol.Processor.Logs (
+  processLogEvents,
+)
+where
+
+import Control.Monad.IO.Class (MonadIO (..))
+import Data.DList (DList)
+import Data.DList qualified as D
+import Data.Machine (Process, ProcessT, mapping, (~>))
+import GHC.Eventlog.Live.Machine.Analysis.Log qualified as M
+import GHC.Eventlog.Live.Machine.Analysis.Thread qualified as M
+import GHC.Eventlog.Live.Machine.Core (Tick)
+import GHC.Eventlog.Live.Machine.Core qualified as M
+import GHC.Eventlog.Live.Machine.WithStartTime (WithStartTime (..))
+import GHC.Eventlog.Live.Otelcol.Config qualified as C
+import GHC.Eventlog.Live.Otelcol.Config.Types (FullConfig (..))
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Core (runIf)
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Logs (ToLogRecord (..))
+import GHC.RTS.Events (Event (..))
+import Proto.Opentelemetry.Proto.Logs.V1.Logs qualified as OL
+
+--------------------------------------------------------------------------------
+-- processLogEvents
+--------------------------------------------------------------------------------
+
+processLogEvents ::
+  (MonadIO m) =>
+  FullConfig ->
+  ProcessT m (Tick (WithStartTime Event)) (Tick (DList OL.LogRecord))
+processLogEvents fullConfig =
+  M.fanoutTick
+    [ processThreadLabel fullConfig
+    , processUserMarker fullConfig
+    , processUserMessage fullConfig
+    ]
+
+--------------------------------------------------------------------------------
+-- UserMessage
+
+processUserMessage :: FullConfig -> Process (Tick (WithStartTime Event)) (Tick (DList OL.LogRecord))
+processUserMessage fullConfig =
+  runIf (C.processorEnabled (.logs) (.userMessage) fullConfig) $
+    M.liftTick M.processUserMessageData
+      ~> M.liftTick (mapping (D.singleton . toLogRecord))
+      ~> M.batchByTicks (C.processorExportBatches (.logs) (.userMessage) fullConfig)
+
+--------------------------------------------------------------------------------
+-- UserMarker
+
+processUserMarker :: FullConfig -> Process (Tick (WithStartTime Event)) (Tick (DList OL.LogRecord))
+processUserMarker fullConfig =
+  runIf (C.processorEnabled (.logs) (.userMarker) fullConfig) $
+    M.liftTick M.processUserMarkerData
+      ~> M.liftTick (mapping (D.singleton . toLogRecord))
+      ~> M.batchByTicks (C.processorExportBatches (.logs) (.userMarker) fullConfig)
+
+--------------------------------------------------------------------------------
+-- ThreadLabel
+
+processThreadLabel :: FullConfig -> Process (Tick (WithStartTime Event)) (Tick (DList OL.LogRecord))
+processThreadLabel fullConfig =
+  runIf (C.processorEnabled (.logs) (.threadLabel) fullConfig) $
+    M.liftTick M.processThreadLabelData
+      ~> M.liftTick (mapping (D.singleton . toLogRecord))
+      ~> M.batchByTicks (C.processorExportBatches (.logs) (.threadLabel) fullConfig)

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Profiles.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Profiles.hs
@@ -7,17 +7,30 @@ Stability   : experimental
 Portability : portable
 -}
 module GHC.Eventlog.Live.Otelcol.Processor.Profiles (
+  processProfileEvents,
   processCallStackData,
 )
 where
 
+import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.State.Strict (State, runState)
-import Data.ProtoLens (Message (defMessage))
+import Data.DList (DList)
+import Data.DList qualified as D
+import Data.Machine (ProcessT, asParts, mapping, (~>))
 import Data.Text (Text)
+import GHC.Eventlog.Live.Data.Metric (Metric (..))
+import GHC.Eventlog.Live.Logger (Logger)
 import GHC.Eventlog.Live.Machine.Analysis.Heap qualified as M
 import GHC.Eventlog.Live.Machine.Analysis.Profile qualified as M
-import GHC.Eventlog.Live.Otelcol.Processor.Profiles.Dictionary (ProfileDictionary, SymbolIndex)
-import GHC.Eventlog.Live.Otelcol.Processor.Profiles.Dictionary qualified as ProfDictionary
+import GHC.Eventlog.Live.Machine.Core (Tick)
+import GHC.Eventlog.Live.Machine.Core qualified as M
+import GHC.Eventlog.Live.Machine.WithStartTime (WithStartTime (..))
+import GHC.Eventlog.Live.Otelcol.Config qualified as C
+import GHC.Eventlog.Live.Otelcol.Config.Types (FullConfig (..))
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Core
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Profiles (ProfileDictionary, SymbolIndex)
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Profiles qualified as ProfDictionary
+import GHC.RTS.Events (Event (..))
 import GHC.Stack.Profiler.Core.SourceLocation qualified as Profiler
 import Lens.Family2 ((.~))
 import Proto.Opentelemetry.Proto.Common.V1.Common qualified as OC
@@ -26,49 +39,97 @@ import Proto.Opentelemetry.Proto.Profiles.V1development.Profiles qualified as OP
 import Proto.Opentelemetry.Proto.Profiles.V1development.Profiles_Fields qualified as OP
 import Proto.Opentelemetry.Proto.Resource.V1.Resource (Resource)
 
+--------------------------------------------------------------------------------
+-- processProfileEvents
+--------------------------------------------------------------------------------
+
+processProfileEvents ::
+  (MonadIO m) =>
+  Logger m ->
+  FullConfig ->
+  ProcessT m (Tick (WithStartTime Event)) (Tick (DList M.CallStackData))
+processProfileEvents verbosity config =
+  M.fanoutTick
+    [ processStackProfSample verbosity config
+    , processCostCentreProfSample verbosity config
+    ]
+
+--------------------------------------------------------------------------------
+-- StackProfSample
+
+processStackProfSample ::
+  (MonadIO m) =>
+  Logger m ->
+  FullConfig ->
+  ProcessT m (Tick (WithStartTime Event)) (Tick (DList M.CallStackData))
+processStackProfSample logger config =
+  runIf (C.processorEnabled (.profiles) (.stackSample) config) $
+    M.liftTick
+      ( M.processStackProfSampleData logger
+          ~> mapping M.stackProfSamples
+          ~> asParts
+          ~> mapping (D.singleton . (.value))
+      )
+      ~> M.batchByTicks (C.processorExportBatches (.profiles) (.stackSample) config)
+
+processCostCentreProfSample ::
+  (MonadIO m) =>
+  Logger m ->
+  FullConfig ->
+  ProcessT m (Tick (WithStartTime Event)) (Tick (DList M.CallStackData))
+processCostCentreProfSample logger config =
+  runIf (C.processorEnabled (.profiles) (.costCentreSample) config) $
+    M.liftTick
+      ( M.processCostCentreProfSampleData logger
+          ~> mapping M.stackProfSamples
+          ~> asParts
+          ~> mapping (D.singleton . (.value))
+      )
+      ~> M.batchByTicks (C.processorExportBatches (.profiles) (.costCentreSample) config)
+
 processCallStackData :: Resource -> OC.InstrumentationScope -> [M.CallStackData] -> (OP.ResourceProfiles, OP.ProfilesDictionary)
-processCallStackData resource instrumentationScope callstacks =
-  let (profile, st) = flip runState ProfDictionary.emptyProfileDictionary $ do
-        sampleNameStrId <- ProfDictionary.getString "__name__"
-        sampleTypeStrId <- ProfDictionary.getString "String"
-        sampleAttrId <-
-          ProfDictionary.getAttribute $
-            messageWith @OP.KeyValueAndUnit
-              [ OP.keyStrindex .~ sampleNameStrId
-              , OP.unitStrindex .~ sampleTypeStrId
-              , OP.value .~ messageWith [OC.stringValue .~ "process_cpu"]
-              ]
+processCallStackData resource instrumentationScope callstacks = (resourceProfiles, profilesDictionary)
+ where
+  scopedProfiles =
+    messageWith
+      [ OP.profiles .~ [profile]
+      , OP.scope .~ instrumentationScope
+      ]
 
-        samples <- traverse (asSample sampleAttrId) callstacks
-        cpuId <- ProfDictionary.getString "stack"
-        unitId <- ProfDictionary.getString "samples"
-        let sampleType :: OP.ValueType
-            sampleType =
-              messageWith
-                [ OP.typeStrindex .~ cpuId
-                , OP.unitStrindex .~ unitId
-                ]
+  resourceProfiles =
+    messageWith
+      [ OP.scopeProfiles .~ [scopedProfiles]
+      , OP.resource .~ resource
+      ]
 
-        pure $
+  profilesDictionary = ProfDictionary.toProfilesDictionary st
+
+  (profile, st) = flip runState ProfDictionary.emptyProfileDictionary $ do
+    sampleNameStrId <- ProfDictionary.getString "__name__"
+    sampleTypeStrId <- ProfDictionary.getString "String"
+    sampleAttrId <-
+      ProfDictionary.getAttribute $
+        messageWith @OP.KeyValueAndUnit
+          [ OP.keyStrindex .~ sampleNameStrId
+          , OP.unitStrindex .~ sampleTypeStrId
+          , OP.value .~ messageWith [OC.stringValue .~ "process_cpu"]
+          ]
+
+    samples <- traverse (asSample sampleAttrId) callstacks
+    cpuId <- ProfDictionary.getString "stack"
+    unitId <- ProfDictionary.getString "samples"
+    let sampleType :: OP.ValueType
+        sampleType =
           messageWith
-            [ OP.samples .~ samples
-            , OP.sampleType .~ sampleType
+            [ OP.typeStrindex .~ cpuId
+            , OP.unitStrindex .~ unitId
             ]
 
-      scopedProfiles =
-        messageWith
-          [ OP.profiles .~ [profile]
-          , OP.scope .~ instrumentationScope
-          ]
-
-      resourceProfiles =
-        messageWith
-          [ OP.scopeProfiles .~ [scopedProfiles]
-          , OP.resource .~ resource
-          ]
-
-      profilesDictionary = ProfDictionary.toProfilesDictionary st
-   in (resourceProfiles, profilesDictionary)
+    pure $
+      messageWith
+        [ OP.samples .~ samples
+        , OP.sampleType .~ sampleType
+        ]
 
 asSample :: SymbolIndex -> M.CallStackData -> State ProfileDictionary OP.Sample
 asSample six stackData = do
@@ -232,10 +293,3 @@ getLocationIndexForCostCentre costCentre = do
       [ OP.lines .~ [line]
       , OP.address .~ 0 -- 0 means unset
       ]
-
---------------------------------------------------------------------------------
--- DSL for writing messages
-
--- | Construct a message with a list of modifications applied.
-messageWith :: (Message msg) => [msg -> msg] -> msg
-messageWith = foldr ($) defMessage

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Threads.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Threads.hs
@@ -1,0 +1,151 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : GHC.Eventlog.Live.Otelcol.Processor.Threads
+Description : Thread Event Processors for OTLP.
+Stability   : experimental
+Portability : portable
+-}
+module GHC.Eventlog.Live.Otelcol.Processor.Threads (
+  processThreadEvents,
+)
+where
+
+import Control.Monad.IO.Class (MonadIO (..))
+import Data.DList (DList)
+import Data.DList qualified as D
+import Data.Machine (ProcessT, asParts, echo, mapping, (~>))
+import Data.Machine.Fanout (fanout)
+import Data.Proxy (Proxy (..))
+import GHC.Eventlog.Live.Logger (Logger)
+import GHC.Eventlog.Live.Machine.Analysis.Capability qualified as M
+import GHC.Eventlog.Live.Machine.Analysis.Thread qualified as M
+import GHC.Eventlog.Live.Machine.Core (Tick)
+import GHC.Eventlog.Live.Machine.Core qualified as M
+import GHC.Eventlog.Live.Machine.WithStartTime (WithStartTime (..))
+import GHC.Eventlog.Live.Machine.WithStartTime qualified as M
+import GHC.Eventlog.Live.Otelcol.Config qualified as C
+import GHC.Eventlog.Live.Otelcol.Config.Types (FullConfig (..))
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Core (runIf)
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Metrics (MetricProcessor (..), asSum, runMetricProcessor, viaSum)
+import GHC.Eventlog.Live.Otelcol.Processor.Common.Traces (asSpan)
+import GHC.RTS.Events (Event (..))
+import Lens.Family2 ((.~))
+import Proto.Opentelemetry.Proto.Metrics.V1.Metrics qualified as OM
+import Proto.Opentelemetry.Proto.Metrics.V1.Metrics_Fields qualified as OM
+import Proto.Opentelemetry.Proto.Trace.V1.Trace qualified as OT
+
+data OneOf a b c = A !a | B !b | C !c
+
+processThreadEvents ::
+  (MonadIO m) =>
+  Logger m ->
+  FullConfig ->
+  ProcessT m (Tick (WithStartTime Event)) (Tick (DList (Either OM.Metric OT.Span)))
+processThreadEvents verbosity fullConfig =
+  runIf (shouldProcessThreadEvents fullConfig) $
+    M.sortByTicks (.value.evTime) fullConfig.eventlogFlushIntervalX
+      ~> M.liftTick
+        ( fanout
+            [ M.validateOrder verbosity (.value.evTime)
+            , runIf (shouldComputeCapabilityUsageSpan fullConfig) $
+                M.processGCSpans verbosity
+                  ~> mapping (D.singleton . A)
+            , runIf (shouldComputeThreadStateSpan fullConfig) $
+                M.processThreadStateSpans' M.tryGetTimeUnixNano (.value) M.setWithStartTime'value verbosity
+                  ~> fanout
+                    [ M.asMutatorSpans' (.value) M.setWithStartTime'value
+                        ~> mapping (D.singleton . B)
+                    , mapping (D.singleton . C)
+                    ]
+            ]
+        )
+      ~> M.liftTick
+        ( asParts
+            ~> mapping repackCapabilityUsageSpanOrThreadStateSpan
+        )
+      ~> fanout
+        [ M.liftTick
+            ( mapping leftToMaybe
+                ~> asParts
+            )
+            ~> M.fanoutTick
+              [ runMetricProcessor
+                  MetricProcessor
+                    { metricProcessorProxy = Proxy @"capabilityUsage"
+                    , dataProcessor = M.processCapabilityUsageMetrics
+                    , aggregators = viaSum
+                    , postProcessor = echo
+                    , unit = "ns"
+                    , asMetric'Data =
+                        asSum
+                          [ OM.aggregationTemporality .~ OM.AGGREGATION_TEMPORALITY_DELTA
+                          , OM.isMonotonic .~ True
+                          ]
+                    }
+                  fullConfig
+                  ~> mapping (fmap (fmap Left))
+              , runIf (C.processorEnabled (.traces) (.capabilityUsage) fullConfig) $
+                  M.liftTick
+                    ( M.dropStartTime
+                        ~> asSpan fullConfig
+                        ~> mapping (D.singleton . Right)
+                    )
+                    ~> M.batchByTick
+              ]
+        , runIf (C.processorEnabled (.traces) (.threadState) fullConfig) $
+            M.liftTick
+              ( mapping rightToMaybe
+                  ~> asParts
+                  ~> asSpan fullConfig
+                  ~> mapping (D.singleton . Right)
+              )
+              ~> M.batchByTick
+        ]
+ where
+  repackCapabilityUsageSpanOrThreadStateSpan = \case
+    A i -> Left $ fmap Left i
+    B i -> Left $ fmap Right i
+    C i -> Right i.value
+
+{- |
+Internal helper.
+Get the `Left` value, if any.
+-}
+leftToMaybe :: Either a b -> Maybe a
+leftToMaybe = either Just (const Nothing)
+
+{- |
+Internal helper.
+Get the `Right` value, if any.
+-}
+rightToMaybe :: Either a b -> Maybe b
+rightToMaybe = either (const Nothing) Just
+
+{- |
+Internal helper.
+Determine whether or not any thread events should be processed at all.
+-}
+shouldProcessThreadEvents :: FullConfig -> Bool
+shouldProcessThreadEvents fullConfig =
+  C.processorEnabled (.metrics) (.capabilityUsage) fullConfig
+    || C.processorEnabled (.traces) (.capabilityUsage) fullConfig
+    || C.processorEnabled (.traces) (.threadState) fullConfig
+
+{- |
+Internal helper.
+Determine whether or not the capability usage spans should be computed.
+-}
+shouldComputeCapabilityUsageSpan :: FullConfig -> Bool
+shouldComputeCapabilityUsageSpan fullConfig =
+  C.processorEnabled (.traces) (.capabilityUsage) fullConfig
+    || C.processorEnabled (.metrics) (.capabilityUsage) fullConfig
+
+{- |
+Internal helper.
+Determine whether or not the thread state spans should be computed.
+-}
+shouldComputeThreadStateSpan :: FullConfig -> Bool
+shouldComputeThreadStateSpan fullConfig =
+  C.processorEnabled (.traces) (.threadState) fullConfig
+    || shouldComputeCapabilityUsageSpan fullConfig

--- a/eventlog-live/eventlog-live.cabal
+++ b/eventlog-live/eventlog-live.cabal
@@ -1,7 +1,7 @@
-cabal-version:   3.0
-name:            eventlog-live
-version:         0.5.0.0
-synopsis:        Live processing of eventlog data.
+cabal-version: 3.0
+name: eventlog-live
+version: 0.5.0.0
+synopsis: Live processing of eventlog data.
 description:
   This package supports live processing of eventlog data.
   It consists of three libraries:
@@ -28,42 +28,41 @@ description:
 
   For more information, see [the README](https://github.com/well-typed/eventlog-live#readme).
 
-license:         BSD-3-Clause
-license-file:    LICENSE
-author:          Wen Kokke
-maintainer:      wen@well-typed.com
-copyright:       (c) 2021-2025 Well-Typed
-build-type:      Simple
-category:        Debug, Monitoring, System
+license: BSD-3-Clause
+license-file: LICENSE
+author: Wen Kokke
+maintainer: wen@well-typed.com
+copyright: (c) 2021-2025 Well-Typed
+build-type: Simple
+category: Debug, Monitoring, System
 extra-doc-files: CHANGELOG.md
 tested-with:
-  GHC ==9.2.8
-   || ==9.4.8
-   || ==9.6.7
-   || ==9.8.4
-   || ==9.10.2
-   || ==9.12.2
+  ghc ==9.2.8 || ==9.4.8 || ==9.6.7 || ==9.8.4 || ==9.10.2 || ==9.12.2
 
 source-repository head
-  type:     git
+  type: git
   location: https://github.com/well-typed/eventlog-live.git
-  subdir:   eventlog-live
+  subdir: eventlog-live
 
 -- 2025-12-09:
 -- This flag should enable switching between concurrent-machines and the
 -- vendored copy of the packages, as it currently does not easily build.
 flag use-concurrent-machines
   description: Use concurrent-machines in place of the vendored copy
-  default:     False
-  manual:      False
+  default: False
+  manual: False
 
 common language
   ghc-options:
-    -Wall -Wcompat -Widentities -Wprepositive-qualified-module
-    -Wredundant-constraints -Wunticked-promoted-constructors
+    -Wall
+    -Wcompat
+    -Widentities
+    -Wprepositive-qualified-module
+    -Wredundant-constraints
+    -Wunticked-promoted-constructors
     -Wunused-packages
 
-  default-language:   Haskell2010
+  default-language: Haskell2010
   default-extensions:
     BangPatterns
     ConstraintKinds
@@ -100,8 +99,8 @@ common language
     ViewPatterns
 
 library
-  import:          language
-  hs-source-dirs:  src
+  import: language
+  hs-source-dirs: src
   exposed-modules:
     GHC.Eventlog.Live.Data.Attribute
     GHC.Eventlog.Live.Data.Group
@@ -125,33 +124,32 @@ library
     GHC.Eventlog.Live.Source.Core
 
   build-depends:
-    , ansi-terminal            >=1.1    && <1.2
-    , base                     >=4.16   && <4.22
-    , bytestring               >=0.11   && <0.13
-    , clock                    >=0.8    && <0.9
-    , co-log-core              >=0.3    && <0.4
-    , dlist                    >=1.0    && <1.1
-    , ghc-events               >=0.20   && <0.21
-    , ghc-stack-profiler-core  >=0.2    && <0.3
-    , hashable                 >=1.4    && <1.6
-    , machines                 >=0.7.4  && <0.8
-    , monad-control            >=1.0    && <1.1
-    , network                  >=3.2.7  && <3.3
-    , optparse-applicative     >=0.17   && <0.20
-    , stm                      >=2.5    && <2.6
-    , text                     >=1.2    && <2.2
-    , transformers             >=0.2    && <0.7
-    , unordered-containers     >=0.2.20 && <0.3
-    , vector                   >=0.11   && <0.14
+    ansi-terminal >=1.1 && <1.2,
+    base >=4.16 && <4.22,
+    bytestring >=0.11 && <0.13,
+    clock >=0.8 && <0.9,
+    co-log-core >=0.3 && <0.4,
+    dlist >=1.0 && <1.1,
+    ghc-events >=0.20 && <0.21,
+    ghc-stack-profiler-core >=0.2 && <0.3,
+    hashable >=1.4 && <1.6,
+    machines >=0.7.4 && <0.8,
+    monad-control >=1.0 && <1.1,
+    network >=3.2.7 && <3.3,
+    optparse-applicative >=0.17 && <0.20,
+    stm >=2.5 && <2.6,
+    text >=1.2 && <2.2,
+    transformers >=0.2 && <0.7,
+    unordered-containers >=0.2.20 && <0.3,
+    vector >=0.11 && <0.14,
 
   -- 2025-12-09:
   -- This configures the build requirements for the vendored copy of
   -- the concurrent-machines package version 0.3.1.5.
   if flag(use-concurrent-machines)
     build-depends: concurrent-machines >=0.1 && <0.4
-
   else
-    ghc-options:    -Wno-prepositive-qualified-module
+    ghc-options: -Wno-prepositive-qualified-module
     hs-source-dirs: vendor/concurrent-machines-0.3.1.5/src
     other-modules:
       Data.Machine.Concurrent
@@ -164,8 +162,8 @@ library
       Data.Machine.Regulated
 
     build-depends:
-      , async              >=2.0.1 && <2.3
-      , containers         >=0.5   && <0.8
-      , lifted-async       >=0.10  && <0.12
-      , time               >=1.4   && <1.16
-      , transformers-base  >=0.4   && <0.5
+      async >=2.0.1 && <2.3,
+      containers >=0.5 && <0.8,
+      lifted-async >=0.10 && <0.12,
+      time >=1.4 && <1.16,
+      transformers-base >=0.4 && <0.5,

--- a/examples/jumpy-jump/jumpy-jump.cabal
+++ b/examples/jumpy-jump/jumpy-jump.cabal
@@ -1,43 +1,41 @@
 cabal-version: 2.4
-name:          jumpy-jump
-version:       0.1.0.0
-synopsis:      Example with an interesting call stack profile.
-description:   Repeatedly jump randomly between ten jumpyJump functions.
-author:        Wen Kokke
-maintainer:    wen@well-typed.com
-copyright:     (c) 2026 Well-Typed
-license:       BSD-3-Clause
-license-file:  LICENSE
-category:      Debug, Monitoring, System, Network
+name: jumpy-jump
+version: 0.1.0.0
+synopsis: Example with an interesting call stack profile.
+description: Repeatedly jump randomly between ten jumpyJump functions.
+author: Wen Kokke
+maintainer: wen@well-typed.com
+copyright: (c) 2026 Well-Typed
+license: BSD-3-Clause
+license-file: LICENSE
+category: Debug, Monitoring, System, Network
 tested-with:
-  GHC ==9.2.8
-   || ==9.4.8
-   || ==9.6.7
-   || ==9.8.4
-   || ==9.10.2
-   || ==9.12.2
+  ghc ==9.2.8 || ==9.4.8 || ==9.6.7 || ==9.8.4 || ==9.10.2 || ==9.12.2
 
 flag use-ghc-stack-profiler
   description: Use ghc-stack-profiler
-  default:     False
-  manual:      True
+  default: False
+  manual: True
 
 executable jumpy-jump
-  main-is:            Main.hs
-  hs-source-dirs:     app
-  default-language:   Haskell2010
+  main-is: Main.hs
+  hs-source-dirs: app
+  default-language: Haskell2010
   default-extensions: TypeApplications
   ghc-options:
-    -threaded -rtsopts -finfo-table-map -fdistinct-constructor-tables
+    -threaded
+    -rtsopts
+    -finfo-table-map
+    -fdistinct-constructor-tables
 
   build-depends:
-    , base             >=4.14  && <5
-    , eventlog-socket  >=0.1.2 && <0.2
-    , random           >=1.2   && <1.4
+    base >=4.14 && <5,
+    eventlog-socket >=0.1.2 && <0.2,
+    random >=1.2 && <1.4,
 
   if flag(use-ghc-stack-profiler)
     build-depends: ghc-stack-profiler >=0.2 && <0.3
-    cpp-options:   -DJUMPY_JUMP_USE_GHC_STACK_PROFILER
+    cpp-options: -DJUMPY_JUMP_USE_GHC_STACK_PROFILER
 
   if impl(ghc <9.4)
     ghc-options: -eventlog

--- a/examples/oddball/oddball.cabal
+++ b/examples/oddball/oddball.cabal
@@ -1,32 +1,31 @@
 cabal-version: 2.4
-name:          oddball
-version:       0.1.0.0
-synopsis:      Example with an interesting heap profile.
-description:   Repeatedly sum long sequences of random numbers.
-author:        Finley McIlwaine
-maintainer:    wen@well-typed.com
-copyright:     (c) 2023 Well-Typed
-license:       BSD-3-Clause
-license-file:  LICENSE
-category:      Debug, Monitoring, System, Network
+name: oddball
+version: 0.1.0.0
+synopsis: Example with an interesting heap profile.
+description: Repeatedly sum long sequences of random numbers.
+author: Finley McIlwaine
+maintainer: wen@well-typed.com
+copyright: (c) 2023 Well-Typed
+license: BSD-3-Clause
+license-file: LICENSE
+category: Debug, Monitoring, System, Network
 tested-with:
-  GHC ==9.2.8
-   || ==9.4.8
-   || ==9.6.7
-   || ==9.8.4
-   || ==9.10.2
-   || ==9.12.2
+  ghc ==9.2.8 || ==9.4.8 || ==9.6.7 || ==9.8.4 || ==9.10.2 || ==9.12.2
 
 executable oddball
-  main-is:            Main.hs
-  hs-source-dirs:     app
-  default-language:   Haskell2010
+  main-is: Main.hs
+  hs-source-dirs: app
+  default-language: Haskell2010
   default-extensions: TypeApplications
-  ghc-options:        -threaded -rtsopts -finfo-table-map
+  ghc-options:
+    -threaded
+    -rtsopts
+    -finfo-table-map
+
   build-depends:
-    , base             >=4.14  && <5
-    , eventlog-socket  >=0.1.2 && <0.2
-    , random           >=1.2   && <1.4
+    base >=4.14 && <5,
+    eventlog-socket >=0.1.2 && <0.2,
+    random >=1.2 && <1.4,
 
   if impl(ghc <9.4)
     ghc-options: -eventlog

--- a/examples/parfib/parfib.cabal
+++ b/examples/parfib/parfib.cabal
@@ -1,31 +1,30 @@
 cabal-version: 2.4
-name:          parfib
-version:       0.1.0.0
-synopsis:      Example with an interesting thread profile.
+name: parfib
+version: 0.1.0.0
+synopsis: Example with an interesting thread profile.
 description:
   An implementation of the Fibonnaci function using spark parallelism.
   Taken from the GHC's @nofib@ benchmarks.
 
-maintainer:    wen@well-typed.com
-license-file:  LICENSE
-category:      Debug, Monitoring, System, Network
+maintainer: wen@well-typed.com
+license-file: LICENSE
+category: Debug, Monitoring, System, Network
 tested-with:
-  GHC ==9.2.8
-   || ==9.4.8
-   || ==9.6.7
-   || ==9.8.4
-   || ==9.10.2
-   || ==9.12.2
+  ghc ==9.2.8 || ==9.4.8 || ==9.6.7 || ==9.8.4 || ==9.10.2 || ==9.12.2
 
 executable parfib
-  main-is:          Main.hs
-  hs-source-dirs:   app
+  main-is: Main.hs
+  hs-source-dirs: app
   default-language: Haskell2010
-  ghc-options:      -threaded -rtsopts -finfo-table-map
+  ghc-options:
+    -threaded
+    -rtsopts
+    -finfo-table-map
+
   build-depends:
-    , base             >=4.14  && <5
-    , eventlog-socket  >=0.1.2 && <0.2
-    , parallel         >=3.2   && <3.3
+    base >=4.14 && <5,
+    eventlog-socket >=0.1.2 && <0.2,
+    parallel >=3.2 && <3.3,
 
   if impl(ghc <9.4)
     ghc-options: -eventlog

--- a/examples/spectral-norm/spectral-norm.cabal
+++ b/examples/spectral-norm/spectral-norm.cabal
@@ -1,35 +1,34 @@
 cabal-version: 2.4
-name:          spectral-norm
-version:       0.1.0.0
-synopsis:      Example with an interesting thread profile.
+name: spectral-norm
+version: 0.1.0.0
+synopsis: Example with an interesting thread profile.
 description:
   An implementation of spectral-norm from The Computer Language Benchmarks Game.
   Taken from the GHC's @nofib@ benchmarks.
 
-maintainer:    wen@well-typed.com
-license-file:  LICENSE
-category:      Debug, Monitoring, System, Network
+maintainer: wen@well-typed.com
+license-file: LICENSE
+category: Debug, Monitoring, System, Network
 tested-with:
-  GHC ==9.2.8
-   || ==9.4.8
-   || ==9.6.7
-   || ==9.8.4
-   || ==9.10.2
-   || ==9.12.2
+  ghc ==9.2.8 || ==9.4.8 || ==9.6.7 || ==9.8.4 || ==9.10.2 || ==9.12.2
 
 executable spectral-norm
-  main-is:            Main.hs
-  hs-source-dirs:     app
-  c-sources:          cbits/main.c
-  default-language:   Haskell2010
+  main-is: Main.hs
+  hs-source-dirs: app
+  c-sources: cbits/main.c
+  default-language: Haskell2010
   default-extensions: BangPatterns
   ghc-options:
-    -threaded -no-hs-main -funbox-strict-fields -optc-O3
-    -fexcess-precision -optc-ffast-math
+    -threaded
+    -no-hs-main
+    -funbox-strict-fields
+    -optc-O3
+    -fexcess-precision
+    -optc-ffast-math
 
   build-depends:
-    , base             >=4.14  && <5
-    , eventlog-socket  >=0.1.2 && <0.2
+    base >=4.14 && <5,
+    eventlog-socket >=0.1.2 && <0.2,
 
   if impl(ghc <9.4)
     ghc-options: -eventlog

--- a/scripts/dev-dependencies.txt
+++ b/scripts/dev-dependencies.txt
@@ -2,6 +2,7 @@ actionlint=1.7.7
 cabal=3.12.1.0
 cabal-docspec=0.0.0.20240703
 cabal-fmt=0.1.12
+cabal-gild=1.8.4.1
 fourmolu=0.16.2.0
 ghc=9.10.3
 hlint=3.10

--- a/scripts/format-cabal-gild.sh
+++ b/scripts/format-cabal-gild.sh
@@ -1,0 +1,36 @@
+#!/bin/sh -e
+
+# Read the expected version:
+EXPECT_VERSION="$(awk -F'=' '/^cabal-gild=/{print$2}' ./scripts/dev-dependencies.txt)"
+
+# Find cabal-gild:
+#
+# 1. Use CABAL_GILD if it is set.
+# 2. Look for cabal-gild-$EXPECTED_VERSION.
+# 3. Look for cabal-gild.
+#
+if [ "${CABAL_GILD}" = "" ]; then
+  if ! CABAL_GILD="$(which "cabal-gild-${EXPECT_VERSION}")"; then
+    if ! CABAL_GILD="$(which "cabal-gild")"; then
+      echo "Requires cabal-gild ${EXPECT_VERSION}; no version found"
+      echo "To install, run:"
+      echo
+      echo "  cabal install cabal-gild-${EXPECT_VERSION}"
+      echo
+      exit 1
+    fi
+  fi
+fi
+
+# Check cabal-gild version:
+ACTUAL_VERSION="$("${CABAL_GILD}" --version | head -n 1)"
+if [ "${ACTUAL_VERSION}" != "${EXPECT_VERSION}" ]; then
+  echo "Requires cabal-gild ${EXPECT_VERSION}; version ${ACTUAL_VERSION} found"
+  # Version mismatch is an error on CI:
+  [ "${CI}" = "" ] || exit 1
+fi
+
+# Format Cabal files
+echo "Format Cabal files with cabal-gild version ${ACTUAL_VERSION}"
+# shellcheck disable=SC2086
+git ls-files --exclude-standard --no-deleted --deduplicate -z '*.cabal' | xargs -0 -L1 ${CABAL_GILD} --mode=format

--- a/scripts/format-fourmolu.sh
+++ b/scripts/format-fourmolu.sh
@@ -31,6 +31,6 @@ if [ "${ACTUAL_VERSION}" != "${EXPECT_VERSION}" ]; then
 fi
 
 # Format Haskell files
-echo "Format Haskell files with cabal-fmt version ${ACTUAL_VERSION}"
+echo "Format Haskell files with fourmolu version ${ACTUAL_VERSION}"
 # shellcheck disable=SC2086
 git ls-files --exclude-standard --no-deleted --deduplicate '*.hs' | xargs -L50 ${FOURMOLU} --mode=inplace

--- a/scripts/lint-cabal-gild.sh
+++ b/scripts/lint-cabal-gild.sh
@@ -1,0 +1,36 @@
+#!/bin/sh -e
+
+# Read the expected version:
+EXPECT_VERSION="$(awk -F'=' '/^cabal-gild=/{print$2}' ./scripts/dev-dependencies.txt)"
+
+# Find cabal-gild:
+#
+# 1. Use CABAL_GILD if it is set.
+# 2. Look for cabal-gild-$EXPECTED_VERSION.
+# 3. Look for cabal-gild.
+#
+if [ "${CABAL_GILD}" = "" ]; then
+  if ! CABAL_GILD="$(which "cabal-gild-${EXPECT_VERSION}")"; then
+    if ! CABAL_GILD="$(which "cabal-gild")"; then
+      echo "Requires cabal-gild ${EXPECT_VERSION}; no version found"
+      echo "To install, run:"
+      echo
+      echo "  cabal install cabal-gild-${EXPECT_VERSION}"
+      echo
+      exit 1
+    fi
+  fi
+fi
+
+# Check cabal-gild version:
+ACTUAL_VERSION="$("${CABAL_GILD}" --version | head -n 1)"
+if [ "${ACTUAL_VERSION}" != "${EXPECT_VERSION}" ]; then
+  echo "Requires cabal-gild ${EXPECT_VERSION}; version ${ACTUAL_VERSION} found"
+  # Version mismatch is an error on CI:
+  [ "${CI}" = "" ] || exit 1
+fi
+
+# Lint Cabal files
+echo "Lint Cabal files with cabal-gild version ${ACTUAL_VERSION}"
+# shellcheck disable=SC2086
+git ls-files --exclude-standard --no-deleted --deduplicate -z '*.cabal' | xargs --verbose -0 -L1 ${CABAL_GILD} --mode=check

--- a/scripts/lint-fourmolu.sh
+++ b/scripts/lint-fourmolu.sh
@@ -31,6 +31,6 @@ if [ "${ACTUAL_VERSION}" != "${EXPECT_VERSION}" ]; then
 fi
 
 # Format Haskell files
-echo "Lint Haskell files with cabal-fmt version ${ACTUAL_VERSION}"
+echo "Lint Haskell files with fourmolu version ${ACTUAL_VERSION}"
 # shellcheck disable=SC2086
 git ls-files --exclude-standard --no-deleted --deduplicate '*.hs' | xargs -L50 ${FOURMOLU} --mode=check

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -34,7 +34,7 @@ if [ ! "${UNSTAGED_CABAL_FILES}" = "" ]; then
 fi
 
 # Run various checks and formatters
-(./scripts/format-cabal-fmt.sh || echo >"${FAIL}")
+(./scripts/format-cabal-gild.sh || echo >"${FAIL}")
 echo
 (./scripts/format-fourmolu.sh || echo >"${FAIL}")
 echo

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,7 +2,7 @@
 
 # List supported dependencies:
 declare -a DEPENDENCIES
-DEPENDENCIES=("cabal-docspec" "cabal-fmt" "fourmolu" "hlint" "nixfmt" "ShellCheck")
+DEPENDENCIES=("cabal-docspec" "cabal-gild" "fourmolu" "hlint" "nixfmt" "ShellCheck")
 
 # Extra dependencies:
 declare -a EXTRA_DEPENDENCIES


### PR DESCRIPTION
This PR performs the long awaited refactoring of `eventlog-live-otelcol`'s main file into modules and switches from `cabal-fmt` to `cabal-gild`.