### PR TITLE
Small refactor of profiles support.

### DIFF
--- a/eventlog-live-otelcol/eventlog-live-otelcol.cabal
+++ b/eventlog-live-otelcol/eventlog-live-otelcol.cabal
@@ -200,7 +200,7 @@ library
     GHC.Eventlog.Live.Otelcol.Processor.Common.Core
     GHC.Eventlog.Live.Otelcol.Processor.Common.Logs
     GHC.Eventlog.Live.Otelcol.Processor.Common.Metrics
-    GHC.Eventlog.Live.Otelcol.Processor.Common.Profiles
+    GHC.Eventlog.Live.Otelcol.Processor.Common.ProfilesDictionary
     GHC.Eventlog.Live.Otelcol.Processor.Common.SymbolTable
     GHC.Eventlog.Live.Otelcol.Processor.Common.Traces
     GHC.Eventlog.Live.Otelcol.Processor.Heap

--- a/eventlog-live-otelcol/eventlog-live-otelcol.cabal
+++ b/eventlog-live-otelcol/eventlog-live-otelcol.cabal
@@ -201,6 +201,7 @@ library
     GHC.Eventlog.Live.Otelcol.Processor.Common.Logs
     GHC.Eventlog.Live.Otelcol.Processor.Common.Metrics
     GHC.Eventlog.Live.Otelcol.Processor.Common.Profiles
+    GHC.Eventlog.Live.Otelcol.Processor.Common.SymbolTable
     GHC.Eventlog.Live.Otelcol.Processor.Common.Traces
     GHC.Eventlog.Live.Otelcol.Processor.Heap
     GHC.Eventlog.Live.Otelcol.Processor.Logs

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol.hs
@@ -43,7 +43,7 @@ import GHC.Eventlog.Live.Otelcol.Options
 import GHC.Eventlog.Live.Otelcol.Processor.Common.Core
 import GHC.Eventlog.Live.Otelcol.Processor.Common.Logs (ToLogRecord (..), toExportLogsServiceRequest, toResourceLogs, toScopeLogs)
 import GHC.Eventlog.Live.Otelcol.Processor.Common.Metrics (toExportMetricsServiceRequest, toResourceMetrics, toScopeMetrics)
-import GHC.Eventlog.Live.Otelcol.Processor.Common.Profiles (toExportProfileServiceRequest)
+import GHC.Eventlog.Live.Otelcol.Processor.Common.ProfilesDictionary (toExportProfileServiceRequest)
 import GHC.Eventlog.Live.Otelcol.Processor.Common.Traces (toExportTracesServiceRequest, toResourceSpans, toScopeSpans)
 import GHC.Eventlog.Live.Otelcol.Processor.Heap (processHeapEvents)
 import GHC.Eventlog.Live.Otelcol.Processor.Logs (processLogEvents)

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Common/Profiles.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Common/Profiles.hs
@@ -30,12 +30,11 @@ where
 
 import Control.Monad.Trans.State.Strict (StateT)
 import Control.Monad.Trans.State.Strict qualified as State
-import Data.Int (Int32)
-import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as Map
 import Data.ProtoLens (Message (..))
 import Data.Text (Text)
 import GHC.Eventlog.Live.Otelcol.Processor.Common.Core (messageWith)
+import GHC.Eventlog.Live.Otelcol.Processor.Common.SymbolTable (SymbolIndex, SymbolTable)
+import GHC.Eventlog.Live.Otelcol.Processor.Common.SymbolTable qualified as ST
 import GHC.Generics (Generic)
 import Lens.Family2 (Lens', (&), (.~), (^.))
 import Lens.Family2.Unchecked (lens)
@@ -51,16 +50,14 @@ toExportProfileServiceRequest profilesData =
     , OPS.dictionary .~ profilesData ^. OPS.dictionary
     ]
 
-type SymbolIndex = Int32
-
 data ProfileDictionary = ProfileDictionary
-  { locationTable :: CommonSymbolTable OP.Location
+  { locationTable :: SymbolTable OP.Location
   -- ^ Common 'OP.Location' table, first entry is the 'defMessage'.
   --   This holds for OTLP 1.9.0.
-  , functionTable :: CommonSymbolTable OP.Function
+  , functionTable :: SymbolTable OP.Function
   -- ^ Common 'OP.Function' table, first entry is the 'defMessage'.
   --   This holds for OTLP 1.9.0.
-  , stringTable :: CommonSymbolTable Text
+  , stringTable :: SymbolTable Text
   -- ^ Common string table, the first entry must be "" per the protobuf
   --   documentation.
   --
@@ -69,16 +66,16 @@ data ProfileDictionary = ProfileDictionary
   --    // string_table[0] must always be "".
   --    repeated string string_table = 5;
   --   @
-  , mappingTable :: CommonSymbolTable OP.Mapping
+  , mappingTable :: SymbolTable OP.Mapping
   -- ^ Common 'OP.Mapping' table, first entry is the 'defMessage'.
   --   This holds for OTLP 1.9.0.
-  , linkTable :: CommonSymbolTable OP.Link
+  , linkTable :: SymbolTable OP.Link
   -- ^ Common 'OP.Link' table, first entry is the 'defMessage'.
   --   This holds for OTLP 1.9.0.
-  , attributeTable :: CommonSymbolTable OP.KeyValueAndUnit
+  , attributeTable :: SymbolTable OP.KeyValueAndUnit
   -- ^ Common 'OP.KeyValueAndUnit' table, first entry is the 'defMessage'.
   --   This holds for OTLP 1.9.0.
-  , stackTable :: CommonSymbolTable OP.Stack
+  , stackTable :: SymbolTable OP.Stack
   -- ^ Common 'OP.Stack' table, first entry is the 'defMessage'.
   --   This holds for OTLP 1.9.0.
   }
@@ -99,40 +96,40 @@ toProfilesDictionary st =
 emptyProfileDictionary :: ProfileDictionary
 emptyProfileDictionary =
   ProfileDictionary
-    { locationTable = commonSymbolTableFromList [defMessage]
-    , functionTable = commonSymbolTableFromList [defMessage]
-    , stringTable = commonSymbolTableFromList [""]
-    , mappingTable = commonSymbolTableFromList [defMessage]
-    , linkTable = commonSymbolTableFromList [defMessage]
-    , attributeTable = commonSymbolTableFromList [defMessage]
-    , stackTable = commonSymbolTableFromList [defMessage]
+    { locationTable = ST.fromList [defMessage]
+    , functionTable = ST.fromList [defMessage]
+    , stringTable = ST.fromList [""]
+    , mappingTable = ST.fromList [defMessage]
+    , linkTable = ST.fromList [defMessage]
+    , attributeTable = ST.fromList [defMessage]
+    , stackTable = ST.fromList [defMessage]
     }
 
 locationTableList :: ProfileDictionary -> [OP.Location]
-locationTableList st = reverse st.locationTable.contents
+locationTableList st = ST.toList st.locationTable
 
 functionTableList :: ProfileDictionary -> [OP.Function]
-functionTableList st = reverse st.functionTable.contents
+functionTableList st = ST.toList st.functionTable
 
 stringTableList :: ProfileDictionary -> [Text]
-stringTableList st = reverse st.stringTable.contents
+stringTableList st = ST.toList st.stringTable
 
 mappingTableList :: ProfileDictionary -> [OP.Mapping]
-mappingTableList st = reverse st.mappingTable.contents
+mappingTableList st = ST.toList st.mappingTable
 
 linkTableList :: ProfileDictionary -> [OP.Link]
-linkTableList st = reverse st.linkTable.contents
+linkTableList st = ST.toList st.linkTable
 
 attributeTableList :: ProfileDictionary -> [OP.KeyValueAndUnit]
-attributeTableList st = reverse st.attributeTable.contents
+attributeTableList st = ST.toList st.attributeTable
 
 stackTableList :: ProfileDictionary -> [OP.Stack]
-stackTableList st = reverse st.stackTable.contents
+stackTableList st = ST.toList st.stackTable
 
-getSymbolIndexFor :: (Ord a, Monad m) => Lens' ProfileDictionary (CommonSymbolTable a) -> a -> StateT ProfileDictionary m SymbolIndex
+getSymbolIndexFor :: (Ord a, Monad m) => Lens' ProfileDictionary (SymbolTable a) -> a -> StateT ProfileDictionary m SymbolIndex
 getSymbolIndexFor accessor a = do
   tbl <- State.gets (^. accessor)
-  let (idx, tbl1) = insertCommonSymbolTable a tbl
+  let (idx, tbl1) = ST.insert a tbl
   State.modify' (\st -> st & accessor .~ tbl1)
   pure idx
 
@@ -156,52 +153,3 @@ getAttribute = getSymbolIndexFor (lens (.attributeTable) (\s v -> s{attributeTab
 
 getStack :: (Monad m) => OP.Stack -> StateT ProfileDictionary m SymbolIndex
 getStack = getSymbolIndexFor (lens (.stackTable) (\s v -> s{stackTable = v}))
-
--------------------------------------------------------------------------------
--- Common Symbol Table implementation
--- TODO: share with `ghc-stack-profiler-core` table?
-
-data CommonSymbolTable a
-  = CommonSymbolTable
-  { counter :: !SymbolIndex
-  , table :: Map a SymbolIndex
-  , contents :: ![a]
-  }
-  deriving (Show, Ord, Eq, Generic)
-
-emptyCommonSymbolTable :: CommonSymbolTable a
-emptyCommonSymbolTable =
-  CommonSymbolTable
-    { counter = 0
-    , table = Map.empty
-    , contents = []
-    }
-
-commonSymbolTableFromList :: (Ord a) => [a] -> CommonSymbolTable a
-commonSymbolTableFromList = foldr go emptyCommonSymbolTable
- where
-  go val tbl0 =
-    let (_, tbl1) = insertCommonSymbolTable val tbl0
-     in tbl1
-
-nextCounter :: CommonSymbolTable a -> (SymbolIndex, CommonSymbolTable a)
-nextCounter tbl = (tbl.counter, tbl{counter = tbl.counter + 1})
-
-insertCommonSymbolTable :: (Ord a) => a -> CommonSymbolTable a -> (SymbolIndex, CommonSymbolTable a)
-insertCommonSymbolTable val tbl =
-  let updateEntry tbl0 Nothing =
-        let (sid, newTbl) = nextCounter tbl0
-         in ((sid, True, newTbl), Just sid)
-      updateEntry newTbl (Just old) =
-        ((old, False, newTbl), Just old)
-
-      ((idx, newEntry, tbl1), newTable) = Map.alterF (updateEntry tbl) val tbl.table
-   in ( idx
-      , tbl1
-          { table = newTable
-          , contents =
-              if newEntry
-                then val : tbl1.contents
-                else tbl1.contents
-          }
-      )

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Common/ProfilesDictionary.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Common/ProfilesDictionary.hs
@@ -6,15 +6,10 @@ Description : Abstraction over ProfilesDictionary for the OTLP protocol.
 Stability   : experimental
 Portability : portable
 -}
-module GHC.Eventlog.Live.Otelcol.Processor.Common.Profiles (
-  toExportProfileServiceRequest,
-
+module GHC.Eventlog.Live.Otelcol.Processor.Common.ProfilesDictionary (
   -- * Dictionary for deduplication logic of common values
-  ProfileDictionary,
-  emptyProfileDictionary,
-
-  -- * Turn a 'ProfileDictionary' into a 'OP.ProfilesDictionary'
-  toProfilesDictionary,
+  ProfilesDictionary,
+  empty,
 
   -- * Retrieve the 'SymbolIndex' for various 'OP.ProfilesData' fields
   SymbolIndex,
@@ -25,6 +20,10 @@ module GHC.Eventlog.Live.Otelcol.Processor.Common.Profiles (
   getLink,
   getAttribute,
   getStack,
+
+  -- * Convert data to the formats used by @hs-opentelemetry-otlp@.
+  toExportProfileServiceRequest,
+  toProfilesDictionary,
 )
 where
 
@@ -36,7 +35,7 @@ import GHC.Eventlog.Live.Otelcol.Processor.Common.Core (messageWith)
 import GHC.Eventlog.Live.Otelcol.Processor.Common.SymbolTable (SymbolIndex, SymbolTable)
 import GHC.Eventlog.Live.Otelcol.Processor.Common.SymbolTable qualified as ST
 import GHC.Generics (Generic)
-import Lens.Family2 (Lens', (&), (.~), (^.))
+import Lens.Family2 (Lens', (.~), (^.))
 import Lens.Family2.Unchecked (lens)
 import Proto.Opentelemetry.Proto.Collector.Profiles.V1development.ProfilesService qualified as OPS
 import Proto.Opentelemetry.Proto.Collector.Profiles.V1development.ProfilesService_Fields qualified as OPS
@@ -50,7 +49,7 @@ toExportProfileServiceRequest profilesData =
     , OPS.dictionary .~ profilesData ^. OPS.dictionary
     ]
 
-data ProfileDictionary = ProfileDictionary
+data ProfilesDictionary = ProfilesDictionary
   { locationTable :: SymbolTable OP.Location
   -- ^ Common 'OP.Location' table, first entry is the 'defMessage'.
   --   This holds for OTLP 1.9.0.
@@ -81,21 +80,21 @@ data ProfileDictionary = ProfileDictionary
   }
   deriving (Show, Ord, Eq, Generic)
 
-toProfilesDictionary :: ProfileDictionary -> OP.ProfilesDictionary
+toProfilesDictionary :: ProfilesDictionary -> OP.ProfilesDictionary
 toProfilesDictionary st =
   messageWith
-    [ OP.locationTable .~ locationTableList st
-    , OP.functionTable .~ functionTableList st
-    , OP.stringTable .~ stringTableList st
-    , OP.mappingTable .~ mappingTableList st
-    , OP.linkTable .~ linkTableList st
-    , OP.attributeTable .~ attributeTableList st
-    , OP.stackTable .~ stackTableList st
+    [ OP.locationTable .~ locations st
+    , OP.functionTable .~ functions st
+    , OP.stringTable .~ strings st
+    , OP.mappingTable .~ mappings st
+    , OP.linkTable .~ links st
+    , OP.attributeTable .~ attributes st
+    , OP.stackTable .~ stacks st
     ]
 
-emptyProfileDictionary :: ProfileDictionary
-emptyProfileDictionary =
-  ProfileDictionary
+empty :: ProfilesDictionary
+empty =
+  ProfilesDictionary
     { locationTable = ST.fromList [defMessage]
     , functionTable = ST.fromList [defMessage]
     , stringTable = ST.fromList [""]
@@ -105,51 +104,51 @@ emptyProfileDictionary =
     , stackTable = ST.fromList [defMessage]
     }
 
-locationTableList :: ProfileDictionary -> [OP.Location]
-locationTableList st = ST.toList st.locationTable
+locations :: ProfilesDictionary -> [OP.Location]
+locations pd = ST.toList pd.locationTable
 
-functionTableList :: ProfileDictionary -> [OP.Function]
-functionTableList st = ST.toList st.functionTable
+functions :: ProfilesDictionary -> [OP.Function]
+functions pd = ST.toList pd.functionTable
 
-stringTableList :: ProfileDictionary -> [Text]
-stringTableList st = ST.toList st.stringTable
+strings :: ProfilesDictionary -> [Text]
+strings pd = ST.toList pd.stringTable
 
-mappingTableList :: ProfileDictionary -> [OP.Mapping]
-mappingTableList st = ST.toList st.mappingTable
+mappings :: ProfilesDictionary -> [OP.Mapping]
+mappings pd = ST.toList pd.mappingTable
 
-linkTableList :: ProfileDictionary -> [OP.Link]
-linkTableList st = ST.toList st.linkTable
+links :: ProfilesDictionary -> [OP.Link]
+links pd = ST.toList pd.linkTable
 
-attributeTableList :: ProfileDictionary -> [OP.KeyValueAndUnit]
-attributeTableList st = ST.toList st.attributeTable
+attributes :: ProfilesDictionary -> [OP.KeyValueAndUnit]
+attributes pd = ST.toList pd.attributeTable
 
-stackTableList :: ProfileDictionary -> [OP.Stack]
-stackTableList st = ST.toList st.stackTable
+stacks :: ProfilesDictionary -> [OP.Stack]
+stacks pd = ST.toList pd.stackTable
 
-getSymbolIndexFor :: (Ord a, Monad m) => Lens' ProfileDictionary (SymbolTable a) -> a -> StateT ProfileDictionary m SymbolIndex
+getSymbolIndexFor :: (Ord a, Monad m) => Lens' ProfilesDictionary (SymbolTable a) -> a -> StateT ProfilesDictionary m SymbolIndex
 getSymbolIndexFor accessor a = do
-  tbl <- State.gets (^. accessor)
-  let (idx, tbl1) = ST.insert a tbl
-  State.modify' (\st -> st & accessor .~ tbl1)
-  pure idx
+  st <- State.gets (^. accessor)
+  let (si, pd') = ST.insert a st
+  State.modify' (accessor .~ pd')
+  pure si
 
-getLocation :: (Monad m) => OP.Location -> StateT ProfileDictionary m SymbolIndex
-getLocation = getSymbolIndexFor (lens (.locationTable) (\s v -> s{locationTable = v}))
+getLocation :: (Monad m) => OP.Location -> StateT ProfilesDictionary m SymbolIndex
+getLocation = getSymbolIndexFor (lens (.locationTable) (\pd st -> pd{locationTable = st}))
 
-getFunction :: (Monad m) => OP.Function -> StateT ProfileDictionary m SymbolIndex
-getFunction = getSymbolIndexFor (lens (.functionTable) (\s v -> s{functionTable = v}))
+getFunction :: (Monad m) => OP.Function -> StateT ProfilesDictionary m SymbolIndex
+getFunction = getSymbolIndexFor (lens (.functionTable) (\pd st -> pd{functionTable = st}))
 
-getString :: (Monad m) => Text -> StateT ProfileDictionary m SymbolIndex
-getString = getSymbolIndexFor (lens (.stringTable) (\s v -> s{stringTable = v}))
+getString :: (Monad m) => Text -> StateT ProfilesDictionary m SymbolIndex
+getString = getSymbolIndexFor (lens (.stringTable) (\pd st -> pd{stringTable = st}))
 
-getMapping :: (Monad m) => OP.Mapping -> StateT ProfileDictionary m SymbolIndex
-getMapping = getSymbolIndexFor (lens (.mappingTable) (\s v -> s{mappingTable = v}))
+getMapping :: (Monad m) => OP.Mapping -> StateT ProfilesDictionary m SymbolIndex
+getMapping = getSymbolIndexFor (lens (.mappingTable) (\pd st -> pd{mappingTable = st}))
 
-getLink :: (Monad m) => OP.Link -> StateT ProfileDictionary m SymbolIndex
-getLink = getSymbolIndexFor (lens (.linkTable) (\s v -> s{linkTable = v}))
+getLink :: (Monad m) => OP.Link -> StateT ProfilesDictionary m SymbolIndex
+getLink = getSymbolIndexFor (lens (.linkTable) (\pd st -> pd{linkTable = st}))
 
-getAttribute :: (Monad m) => OP.KeyValueAndUnit -> StateT ProfileDictionary m SymbolIndex
-getAttribute = getSymbolIndexFor (lens (.attributeTable) (\s v -> s{attributeTable = v}))
+getAttribute :: (Monad m) => OP.KeyValueAndUnit -> StateT ProfilesDictionary m SymbolIndex
+getAttribute = getSymbolIndexFor (lens (.attributeTable) (\pd st -> pd{attributeTable = st}))
 
-getStack :: (Monad m) => OP.Stack -> StateT ProfileDictionary m SymbolIndex
-getStack = getSymbolIndexFor (lens (.stackTable) (\s v -> s{stackTable = v}))
+getStack :: (Monad m) => OP.Stack -> StateT ProfilesDictionary m SymbolIndex
+getStack = getSymbolIndexFor (lens (.stackTable) (\pd st -> pd{stackTable = st}))

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Common/SymbolTable.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Common/SymbolTable.hs
@@ -1,0 +1,73 @@
+{- |
+Module      : GHC.Eventlog.Live.Otelcol.Processor.Common.SymbolTable
+Description : Abstract symbol table datatype.
+Stability   : experimental
+Portability : portable
+-}
+module GHC.Eventlog.Live.Otelcol.Processor.Common.SymbolTable (
+  SymbolIndex,
+  SymbolTable,
+  empty,
+  elemIndex,
+  toList,
+  fromList,
+  insert,
+)
+where
+
+import Data.Int (Int32)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import GHC.Generics (Generic)
+
+type SymbolIndex = Int32
+
+data SymbolTable a
+  = SymbolTable
+  { nextSymbolIndex :: !SymbolIndex
+  -- ^
+  --   The next unused `SymbolIndex`.
+  --
+  --   > st.nextSymbolIndex == length st.entriesReversed
+  , entryToSymbolIndex :: !(Map a SymbolIndex)
+  -- ^
+  --   A map from entries to their `SymbolIndex`.
+  --
+  --   > toList st !! (st.entryToSymbolIndex Map.! a) == a
+  , entriesReversed :: ![a] -- reverse order of insertion into entryToSymbolIndex
+
+  -- ^
+  --   A list of entries in the `SymbolTable` in reverse order.
+  }
+  deriving (Show, Ord, Eq, Generic)
+
+empty :: SymbolTable a
+empty =
+  SymbolTable
+    { nextSymbolIndex = 0
+    , entryToSymbolIndex = Map.empty
+    , entriesReversed = []
+    }
+
+elemIndex :: (Ord a) => a -> SymbolTable a -> Maybe SymbolIndex
+elemIndex a st = Map.lookup a st.entryToSymbolIndex
+
+toList :: SymbolTable a -> [a]
+toList st = reverse st.entriesReversed
+
+fromList :: (Ord a) => [a] -> SymbolTable a
+fromList = foldr (\val st -> snd (insert val st)) empty
+
+insert :: (Ord a) => a -> SymbolTable a -> (SymbolIndex, SymbolTable a)
+insert a st = (si, st'')
+ where
+  ((si, isNew, st'), entryToSymbolIndex') = Map.alterF (updateEntry st) a st.entryToSymbolIndex
+  entriesReversed' = if isNew then a : st'.entriesReversed else st'.entriesReversed
+  st'' = st'{entryToSymbolIndex = entryToSymbolIndex', entriesReversed = entriesReversed'}
+
+updateEntry :: SymbolTable a -> Maybe SymbolIndex -> ((SymbolIndex, Bool, SymbolTable a), Maybe SymbolIndex)
+updateEntry st Nothing = let (si, st') = freshSymbolIndex st in ((si, True, st'), Just si)
+updateEntry st (Just si) = ((si, False, st), Just si)
+
+freshSymbolIndex :: SymbolTable a -> (SymbolIndex, SymbolTable a)
+freshSymbolIndex st = (st.nextSymbolIndex, st{nextSymbolIndex = st.nextSymbolIndex + 1})

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Profiles.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Profiles.hs
@@ -28,8 +28,8 @@ import GHC.Eventlog.Live.Machine.WithStartTime (WithStartTime (..))
 import GHC.Eventlog.Live.Otelcol.Config qualified as C
 import GHC.Eventlog.Live.Otelcol.Config.Types (FullConfig (..))
 import GHC.Eventlog.Live.Otelcol.Processor.Common.Core
-import GHC.Eventlog.Live.Otelcol.Processor.Common.Profiles (ProfileDictionary, SymbolIndex)
-import GHC.Eventlog.Live.Otelcol.Processor.Common.Profiles qualified as ProfDictionary
+import GHC.Eventlog.Live.Otelcol.Processor.Common.ProfilesDictionary (ProfilesDictionary, SymbolIndex)
+import GHC.Eventlog.Live.Otelcol.Processor.Common.ProfilesDictionary qualified as PD
 import GHC.RTS.Events (Event (..))
 import GHC.Stack.Profiler.Core.SourceLocation qualified as Profiler
 import Lens.Family2 ((.~))
@@ -102,13 +102,13 @@ processCallStackData resource instrumentationScope callstacks = (resourceProfile
       , OP.resource .~ resource
       ]
 
-  profilesDictionary = ProfDictionary.toProfilesDictionary st
+  profilesDictionary = PD.toProfilesDictionary st
 
-  (profile, st) = flip runState ProfDictionary.emptyProfileDictionary $ do
-    sampleNameStrId <- ProfDictionary.getString "__name__"
-    sampleTypeStrId <- ProfDictionary.getString "String"
+  (profile, st) = flip runState PD.empty $ do
+    sampleNameStrId <- PD.getString "__name__"
+    sampleTypeStrId <- PD.getString "String"
     sampleAttrId <-
-      ProfDictionary.getAttribute $
+      PD.getAttribute $
         messageWith @OP.KeyValueAndUnit
           [ OP.keyStrindex .~ sampleNameStrId
           , OP.unitStrindex .~ sampleTypeStrId
@@ -116,8 +116,8 @@ processCallStackData resource instrumentationScope callstacks = (resourceProfile
           ]
 
     samples <- traverse (asSample sampleAttrId) callstacks
-    cpuId <- ProfDictionary.getString "stack"
-    unitId <- ProfDictionary.getString "samples"
+    cpuId <- PD.getString "stack"
+    unitId <- PD.getString "samples"
     let sampleType :: OP.ValueType
         sampleType =
           messageWith
@@ -131,21 +131,21 @@ processCallStackData resource instrumentationScope callstacks = (resourceProfile
         , OP.sampleType .~ sampleType
         ]
 
-asSample :: SymbolIndex -> M.CallStackData -> State ProfileDictionary OP.Sample
+asSample :: SymbolIndex -> M.CallStackData -> State ProfilesDictionary OP.Sample
 asSample six stackData = do
   locIndices <- traverse toIndex stackData.stack
   s <-
-    ProfDictionary.getStack $
+    PD.getStack $
       messageWith
         [ OP.locationIndices .~ locIndices
         ]
 
-  sampleThreadKeyStrId <- ProfDictionary.getString "thread"
-  sampleCapKeyStrId <- ProfDictionary.getString "capability"
-  sampleNumberUnitStrId <- ProfDictionary.getString "Number"
+  sampleThreadKeyStrId <- PD.getString "thread"
+  sampleCapKeyStrId <- PD.getString "capability"
+  sampleNumberUnitStrId <- PD.getString "Number"
 
   threadAttrId <-
-    ProfDictionary.getAttribute $
+    PD.getAttribute $
       messageWith @OP.KeyValueAndUnit
         [ OP.keyStrindex .~ sampleThreadKeyStrId
         , OP.unitStrindex .~ sampleNumberUnitStrId
@@ -153,7 +153,7 @@ asSample six stackData = do
         ]
 
   capAttrId <-
-    ProfDictionary.getAttribute $
+    PD.getAttribute $
       messageWith @OP.KeyValueAndUnit
         [ OP.keyStrindex .~ sampleCapKeyStrId
         , OP.unitStrindex .~ sampleNumberUnitStrId
@@ -171,19 +171,19 @@ asSample six stackData = do
              ]
       ]
  where
-  toIndex :: M.StackItemData -> State ProfileDictionary SymbolIndex
+  toIndex :: M.StackItemData -> State ProfilesDictionary SymbolIndex
   toIndex = \case
     M.IpeData infoTable -> getLocationIndexForInfoTable infoTable
     M.UserMessageData message -> getLocationIndexForText message
     M.SourceLocationData srcLoc -> getLocationIndexForSourceLocation srcLoc
     M.CostCentreData costCentre -> getLocationIndexForCostCentre costCentre
 
-getLocationIndexForSourceLocation :: Profiler.SourceLocation -> State ProfileDictionary SymbolIndex
+getLocationIndexForSourceLocation :: Profiler.SourceLocation -> State ProfilesDictionary SymbolIndex
 getLocationIndexForSourceLocation srcLoc = do
-  functionNameId <- ProfDictionary.getString $ Profiler.functionName srcLoc
-  fileNameId <- ProfDictionary.getString $ Profiler.fileName srcLoc
+  functionNameId <- PD.getString $ Profiler.functionName srcLoc
+  fileNameId <- PD.getString $ Profiler.fileName srcLoc
   funcIdx <-
-    ProfDictionary.getFunction $
+    PD.getFunction $
       messageWith
         [ OP.nameStrindex .~ functionNameId
         , OP.systemNameStrindex .~ 0 -- 0 means unset
@@ -199,17 +199,17 @@ getLocationIndexForSourceLocation srcLoc = do
           , OP.column .~ fromIntegral (Profiler.column srcLoc)
           ]
 
-  ProfDictionary.getLocation $
+  PD.getLocation $
     messageWith
       [ OP.lines .~ [line]
       , OP.mappingIndex .~ 0 -- 0 means unset
       ]
 
-getLocationIndexForText :: Text -> State ProfileDictionary SymbolIndex
+getLocationIndexForText :: Text -> State ProfilesDictionary SymbolIndex
 getLocationIndexForText msg = do
-  textId <- ProfDictionary.getString msg
+  textId <- PD.getString msg
   funcIdx <-
-    ProfDictionary.getFunction $
+    PD.getFunction $
       messageWith
         [ OP.nameStrindex .~ textId
         , OP.systemNameStrindex .~ 0 -- 0 means unset
@@ -225,24 +225,24 @@ getLocationIndexForText msg = do
           , OP.column .~ 0 -- 0 means unset
           ]
 
-  ProfDictionary.getLocation $
+  PD.getLocation $
     messageWith
       [ OP.lines .~ [line]
       ]
 
-getLocationIndexForInfoTable :: M.InfoTable -> State ProfileDictionary SymbolIndex
+getLocationIndexForInfoTable :: M.InfoTable -> State ProfilesDictionary SymbolIndex
 getLocationIndexForInfoTable infoTable = do
-  infoTableNameId <- ProfDictionary.getString infoTable.infoTableName
+  infoTableNameId <- PD.getString infoTable.infoTableName
   let label =
         if (infoTable.infoTableLabel) == ""
           then infoTable.infoTableModule <> ":" <> infoTable.infoTableName
           else infoTable.infoTableModule <> ":" <> infoTable.infoTableLabel
-  infoTableFuncNameId <- ProfDictionary.getString label
+  infoTableFuncNameId <- PD.getString label
   -- tyDesc <- getText infoTable.infoTableTyDesc
   --
-  infoTableSrcLocId <- ProfDictionary.getString infoTable.infoTableSrcLoc
+  infoTableSrcLocId <- PD.getString infoTable.infoTableSrcLoc
   funcIdx <-
-    ProfDictionary.getFunction $
+    PD.getFunction $
       messageWith
         [ OP.nameStrindex .~ infoTableFuncNameId
         , OP.systemNameStrindex .~ infoTableNameId
@@ -258,21 +258,21 @@ getLocationIndexForInfoTable infoTable = do
           , OP.column .~ 0 -- 0 means unset
           ]
 
-  ProfDictionary.getLocation $
+  PD.getLocation $
     messageWith
       [ OP.lines .~ [line]
       , OP.address .~ 0 -- 0 means unset
       ]
 
-getLocationIndexForCostCentre :: M.CostCentre -> State ProfileDictionary SymbolIndex
+getLocationIndexForCostCentre :: M.CostCentre -> State ProfilesDictionary SymbolIndex
 getLocationIndexForCostCentre costCentre = do
   let label = costCentre.costCentreModule <> ":" <> costCentre.costCentreLabel
-  costCentreFuncNameId <- ProfDictionary.getString label
+  costCentreFuncNameId <- PD.getString label
   -- tyDesc <- getText infoTable.infoTableTyDesc
   --
-  costCentreSrcLocId <- ProfDictionary.getString costCentre.costCentreSrcLoc
+  costCentreSrcLocId <- PD.getString costCentre.costCentreSrcLoc
   funcIdx <-
-    ProfDictionary.getFunction $
+    PD.getFunction $
       messageWith
         [ OP.nameStrindex .~ costCentreFuncNameId
         , OP.systemNameStrindex .~ costCentreFuncNameId
@@ -288,7 +288,7 @@ getLocationIndexForCostCentre costCentre = do
           , OP.column .~ 0 -- 0 means unset
           ]
 
-  ProfDictionary.getLocation $
+  PD.getLocation $
     messageWith
       [ OP.lines .~ [line]
       , OP.address .~ 0 -- 0 means unset

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Profiles.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Processor/Profiles.hs
@@ -173,7 +173,7 @@ asSample six stackData = do
  where
   toIndex :: M.StackItemData -> State ProfilesDictionary SymbolIndex
   toIndex = \case
-    M.IpeData infoTable -> getLocationIndexForInfoTable infoTable
+    M.IpeData infoProv -> getLocationIndexForInfoTable infoProv
     M.UserMessageData message -> getLocationIndexForText message
     M.SourceLocationData srcLoc -> getLocationIndexForSourceLocation srcLoc
     M.CostCentreData costCentre -> getLocationIndexForCostCentre costCentre
@@ -230,23 +230,23 @@ getLocationIndexForText msg = do
       [ OP.lines .~ [line]
       ]
 
-getLocationIndexForInfoTable :: M.InfoTable -> State ProfilesDictionary SymbolIndex
-getLocationIndexForInfoTable infoTable = do
-  infoTableNameId <- PD.getString infoTable.infoTableName
+getLocationIndexForInfoTable :: M.InfoProv -> State ProfilesDictionary SymbolIndex
+getLocationIndexForInfoTable infoProv = do
+  ipNameId <- PD.getString infoProv.ipName
   let label =
-        if (infoTable.infoTableLabel) == ""
-          then infoTable.infoTableModule <> ":" <> infoTable.infoTableName
-          else infoTable.infoTableModule <> ":" <> infoTable.infoTableLabel
-  infoTableFuncNameId <- PD.getString label
-  -- tyDesc <- getText infoTable.infoTableTyDesc
+        if (infoProv.ipLabel) == ""
+          then infoProv.ipModule <> ":" <> infoProv.ipName
+          else infoProv.ipModule <> ":" <> infoProv.ipLabel
+  infoProvFuncNameId <- PD.getString label
+  -- tyDesc <- getText infoProv.infoProvTyDesc
   --
-  infoTableSrcLocId <- PD.getString infoTable.infoTableSrcLoc
+  ipSrcLocId <- PD.getString infoProv.ipSrcLoc
   funcIdx <-
     PD.getFunction $
       messageWith
-        [ OP.nameStrindex .~ infoTableFuncNameId
-        , OP.systemNameStrindex .~ infoTableNameId
-        , OP.filenameStrindex .~ infoTableSrcLocId -- 0 means unset
+        [ OP.nameStrindex .~ infoProvFuncNameId
+        , OP.systemNameStrindex .~ ipNameId
+        , OP.filenameStrindex .~ ipSrcLocId -- 0 means unset
         , OP.startLine .~ 0 -- 0 means unset
         ]
 
@@ -268,7 +268,7 @@ getLocationIndexForCostCentre :: M.CostCentre -> State ProfilesDictionary Symbol
 getLocationIndexForCostCentre costCentre = do
   let label = costCentre.costCentreModule <> ":" <> costCentre.costCentreLabel
   costCentreFuncNameId <- PD.getString label
-  -- tyDesc <- getText infoTable.infoTableTyDesc
+  -- tyDesc <- getText infoProv.infoProvTyDesc
   --
   costCentreSrcLocId <- PD.getString costCentre.costCentreSrcLoc
   funcIdx <-

--- a/eventlog-live/src/GHC/Eventlog/Live/Machine/Analysis/Heap.hs
+++ b/eventlog-live/src/GHC/Eventlog/Live/Machine/Analysis/Heap.hs
@@ -25,8 +25,8 @@ module GHC.Eventlog.Live.Machine.Analysis.Heap (
   heapProfBreakdownShow,
 
   -- ** Things fendor doesn't want to reimplement
-  InfoTable (..),
-  InfoTablePtr (..),
+  InfoProv (..),
+  InfoProvPtr (..),
   HeapProfBreakdown,
   metric,
 ) where
@@ -222,30 +222,30 @@ insertHeapProfSampleString logger heapProfLabel heapProfSample heapProfSamples =
 Internal helper.
 The type of info table pointers.
 -}
-newtype InfoTablePtr = InfoTablePtr Word64
+newtype InfoProvPtr = InfoProvPtr Word64
   deriving newtype (Eq, Hashable, Ord)
 
-instance Show InfoTablePtr where
-  showsPrec :: Int -> InfoTablePtr -> ShowS
-  showsPrec _ (InfoTablePtr ptr) =
+instance Show InfoProvPtr where
+  showsPrec :: Int -> InfoProvPtr -> ShowS
+  showsPrec _ (InfoProvPtr ptr) =
     showString "0x" . showHex ptr
 
-instance Read InfoTablePtr where
-  readsPrec :: Int -> ReadS InfoTablePtr
-  readsPrec _ = readP_to_S (InfoTablePtr <$> (P.string "0x" *> readHexP))
+instance Read InfoProvPtr where
+  readsPrec :: Int -> ReadS InfoProvPtr
+  readsPrec _ = readP_to_S (InfoProvPtr <$> (P.string "0x" *> readHexP))
 
 {- |
 Internal helper.
 The type of an info table entry, as produced by the `E.InfoTableProv` event.
 -}
-data InfoTable = InfoTable
-  { infoTablePtr :: !InfoTablePtr
-  , infoTableName :: !Text
-  , infoTableClosureDesc :: !Int
-  , infoTableTyDesc :: !Text
-  , infoTableLabel :: !Text
-  , infoTableModule :: !Text
-  , infoTableSrcLoc :: !Text
+data InfoProv = InfoProv
+  { ipPtr :: !InfoProvPtr -- TODO: Remove this field.
+  , ipName :: !Text
+  , ipClosureDesc :: !Int
+  , ipTyDesc :: !Text
+  , ipLabel :: !Text
+  , ipModule :: !Text
+  , ipSrcLoc :: !Text
   }
   deriving (Show, Eq, Ord)
 
@@ -255,7 +255,7 @@ The type of the state kept by `processHeapProfSampleData`.
 -}
 data HeapProfSampleState = HeapProfSampleState
   { eitherShouldWarnOrHeapProfBreakdown :: !(Either Bool HeapProfBreakdown)
-  , infoTableMap :: !(HashMap InfoTablePtr InfoTable)
+  , infoProvMap :: !(HashMap InfoProvPtr InfoProv)
   , heapProfSampleEraStack :: ![Word64]
   , maybeHeapProfSampleData :: !(Maybe HeapProfSampleData)
   }
@@ -268,10 +268,10 @@ We track info tables until (1) we learn that the RTS is not run with @-hi@,
 or (2) we see the first heap profiling sample and don't yet know for sure
 that the RTS is run with @-hi@.
 -}
-shouldTrackInfoTableMap :: Either Bool HeapProfBreakdown -> Bool
-shouldTrackInfoTableMap (Left _shouldWarn) = True
-shouldTrackInfoTableMap (Right HeapProfBreakdownInfoTable) = True
-shouldTrackInfoTableMap _ = False
+shouldTrackInfoProvMap :: Either Bool HeapProfBreakdown -> Bool
+shouldTrackInfoProvMap (Left _shouldWarn) = True
+shouldTrackInfoProvMap (Right HeapProfBreakdownInfoTable) = True
+shouldTrackInfoProvMap _ = False
 
 {- |
 Internal helper.
@@ -300,7 +300,7 @@ processHeapProfSampleData logger maybeHeapProfBreakdown =
     go
       HeapProfSampleState
         { eitherShouldWarnOrHeapProfBreakdown = maybe (Left True) Right maybeHeapProfBreakdown
-        , infoTableMap = mempty
+        , infoProvMap = mempty
         , heapProfSampleEraStack = mempty
         , maybeHeapProfSampleData = mempty
         }
@@ -322,19 +322,19 @@ processHeapProfSampleData logger maybeHeapProfBreakdown =
             go st{eitherShouldWarnOrHeapProfBreakdown = Right heapProfBreakdown}
       -- Announces an info table entry.
       E.InfoTableProv{..}
-        | shouldTrackInfoTableMap eitherShouldWarnOrHeapProfBreakdown -> do
-            let infoTablePtr = InfoTablePtr itInfo
-                infoTable =
-                  InfoTable
-                    { infoTablePtr = infoTablePtr
-                    , infoTableName = itTableName
-                    , infoTableClosureDesc = itClosureDesc
-                    , infoTableTyDesc = itTyDesc
-                    , infoTableLabel = itLabel
-                    , infoTableModule = itModule
-                    , infoTableSrcLoc = itSrcLoc
+        | shouldTrackInfoProvMap eitherShouldWarnOrHeapProfBreakdown -> do
+            let ipPtr = InfoProvPtr itInfo
+                infoProv =
+                  InfoProv
+                    { ipPtr = ipPtr
+                    , ipName = itTableName
+                    , ipClosureDesc = itClosureDesc
+                    , ipTyDesc = itTyDesc
+                    , ipLabel = itLabel
+                    , ipModule = itModule
+                    , ipSrcLoc = itSrcLoc
                     }
-            go st{infoTableMap = M.insert infoTablePtr infoTable infoTableMap}
+            go st{infoProvMap = M.insert ipPtr infoProv infoProvMap}
       -- Announces the beginning of a heap profile sample.
       E.HeapProfSampleBegin{..} -> do
         -- Check that maybeHeapProfSampleData is Nothing.
@@ -392,7 +392,7 @@ processHeapProfSampleData logger maybeHeapProfBreakdown =
                   \         you must also pass the heap profile type to this executable.\n\
                   \         See: https://gitlab.haskell.org/ghc/ghc/-/commit/76d392a"
             lift $ writeLog logger WARN $ msg
-            go st{eitherShouldWarnOrHeapProfBreakdown = Left False, infoTableMap = mempty}
+            go st{eitherShouldWarnOrHeapProfBreakdown = Left False, infoProvMap = mempty}
         -- If the heap profile breakdown is biographical, issue a warning, then disable warnings.
         | Right HeapProfBreakdownBiography <- eitherShouldWarnOrHeapProfBreakdown -> do
             let msg =
@@ -401,14 +401,14 @@ processHeapProfSampleData logger maybeHeapProfBreakdown =
                       "Unsupported heap profile breakdown %s"
                       (heapProfBreakdownShow HeapProfBreakdownBiography)
             lift $ writeLog logger WARN $ msg
-            go st{eitherShouldWarnOrHeapProfBreakdown = Left False, infoTableMap = mempty}
+            go st{eitherShouldWarnOrHeapProfBreakdown = Left False, infoProvMap = mempty}
         -- If there is a heap profile breakdown, handle it appropriately.
         | Right heapProfBreakdown <- eitherShouldWarnOrHeapProfBreakdown -> do
             -- If the heap profile breakdown is by info table, add the info table.
-            let maybeInfoTable
+            let maybeInfoProv
                   | isHeapProfBreakdownInfoTable heapProfBreakdown = do
-                      !infoTablePtr <- readMaybe (T.unpack heapProfLabel)
-                      M.lookup infoTablePtr infoTableMap
+                      !ipPtr <- readMaybe (T.unpack heapProfLabel)
+                      M.lookup ipPtr infoProvMap
                   | otherwise = Nothing
             -- Get the HeapProfSampleData
             heapProfSampleData <-
@@ -429,12 +429,12 @@ processHeapProfSampleData logger maybeHeapProfBreakdown =
                     , "heapProfId" ~= heapProfId
                     , "heapProfLabel" ~= heapProfLabel
                     , "heapProfSampleEra" ~= (fst <$> L.uncons heapProfSampleEraStack)
-                    , "infoTableName" ~= fmap (.infoTableName) maybeInfoTable
-                    , "infoTableClosureDesc" ~= fmap (.infoTableClosureDesc) maybeInfoTable
-                    , "infoTableTyDesc" ~= fmap (.infoTableTyDesc) maybeInfoTable
-                    , "infoTableLabel" ~= fmap (.infoTableLabel) maybeInfoTable
-                    , "infoTableModule" ~= fmap (.infoTableModule) maybeInfoTable
-                    , "infoTableSrcLoc" ~= fmap (.infoTableSrcLoc) maybeInfoTable
+                    , "ipName" ~= fmap (.ipName) maybeInfoProv
+                    , "ipClosureDesc" ~= fmap (.ipClosureDesc) maybeInfoProv
+                    , "ipTyDesc" ~= fmap (.ipTyDesc) maybeInfoProv
+                    , "ipLabel" ~= fmap (.ipLabel) maybeInfoProv
+                    , "ipModule" ~= fmap (.ipModule) maybeInfoProv
+                    , "ipSrcLoc" ~= fmap (.ipSrcLoc) maybeInfoProv
                     ]
             heapProfSampleData' <-
               lift $ insertHeapProfSampleString logger heapProfLabel heapProfSample heapProfSampleData
@@ -442,7 +442,7 @@ processHeapProfSampleData logger maybeHeapProfBreakdown =
             go
               st
                 { -- If we're not profiling with -hi, discard the info table map
-                  infoTableMap = if isHeapProfBreakdownInfoTable heapProfBreakdown then st.infoTableMap else mempty
+                  infoProvMap = if isHeapProfBreakdownInfoTable heapProfBreakdown then st.infoProvMap else mempty
                 , -- Add the update HeapProfSampleData
                   maybeHeapProfSampleData = Just heapProfSampleData'
                 }

--- a/eventlog-live/src/GHC/Eventlog/Live/Machine/Analysis/Profile.hs
+++ b/eventlog-live/src/GHC/Eventlog/Live/Machine/Analysis/Profile.hs
@@ -31,7 +31,7 @@ import Data.Vector.Unboxed qualified as UVector
 import Data.Word
 import GHC.Eventlog.Live.Data.Metric
 import GHC.Eventlog.Live.Logger (Logger, writeException)
-import GHC.Eventlog.Live.Machine.Analysis.Heap (InfoTable (..), InfoTablePtr (..), metric)
+import GHC.Eventlog.Live.Machine.Analysis.Heap (InfoProv (..), InfoProvPtr (..), metric)
 import GHC.Eventlog.Live.Machine.WithStartTime (WithStartTime (..))
 import GHC.Generics (Generic)
 import GHC.RTS.Events (Event (..))
@@ -41,7 +41,7 @@ import GHC.Stack.Profiler.Core.SymbolTable qualified as SPCS
 import GHC.Stack.Profiler.Core.ThreadSample qualified as SPCT
 
 data StackProfSampleState = StackProfSampleState
-  { infoTableMap :: !(HashMap InfoTablePtr InfoTable)
+  { infoTableMap :: !(HashMap InfoProvPtr InfoProv)
   , -- TODO: this should probably be a maybe?
     -- We could report when interleaved messages are present
     stackProfSampleChunk :: ![SPCE.BinaryCallStackMessage]
@@ -93,14 +93,14 @@ data CostCentre = CostCentre
   deriving (Show, Eq, Ord, Generic)
 
 data StackItemData
-  = IpeData !InfoTable
+  = IpeData !InfoProv
   | UserMessageData !Text
   | SourceLocationData !SPCT.SourceLocation
   | CostCentreData !CostCentre
   deriving (Show, Eq, Ord, Generic)
 
-shouldTrackInfoTableMap :: Bool
-shouldTrackInfoTableMap = True
+shouldTrackInfoProvMap :: Bool
+shouldTrackInfoProvMap = True
 
 shouldTrackCostCentreMap :: Bool
 shouldTrackCostCentreMap = True
@@ -185,17 +185,17 @@ processStackProfSampleData logger =
     await >>= \i -> case i.value.evSpec of
       -- Announces an info table entry.
       E.InfoTableProv{..}
-        | shouldTrackInfoTableMap -> do
-            let infoTablePtr = InfoTablePtr itInfo
+        | shouldTrackInfoProvMap -> do
+            let infoTablePtr = InfoProvPtr itInfo
                 infoTable =
-                  InfoTable
-                    { infoTablePtr = infoTablePtr
-                    , infoTableName = itTableName
-                    , infoTableClosureDesc = itClosureDesc
-                    , infoTableTyDesc = itTyDesc
-                    , infoTableLabel = itLabel
-                    , infoTableModule = itModule
-                    , infoTableSrcLoc = itSrcLoc
+                  InfoProv
+                    { ipPtr = infoTablePtr
+                    , ipName = itTableName
+                    , ipClosureDesc = itClosureDesc
+                    , ipTyDesc = itTyDesc
+                    , ipLabel = itLabel
+                    , ipModule = itModule
+                    , ipSrcLoc = itSrcLoc
                     }
             go st{infoTableMap = M.insert infoTablePtr infoTable st.infoTableMap}
       E.UserBinaryMessage{payload} ->
@@ -261,9 +261,9 @@ hydrateBinaryEventlog spst msg = (callStackData, spst{stackProfSampleChunk = []}
           mapMaybe (toStackItemData spst.infoTableMap) $ SPCT.callStack callStackMessage
       }
 
-toStackItemData :: HashMap InfoTablePtr InfoTable -> SPCT.StackItem -> Maybe StackItemData
+toStackItemData :: HashMap InfoProvPtr InfoProv -> SPCT.StackItem -> Maybe StackItemData
 toStackItemData tbl = \case
-  SPCT.IpeId iid -> IpeData <$> HashMap.lookup (InfoTablePtr $ SPCE.getIpeId iid) tbl
+  SPCT.IpeId iid -> IpeData <$> HashMap.lookup (InfoProvPtr $ SPCE.getIpeId iid) tbl
   SPCT.UserMessage msg -> Just $ UserMessageData $ Text.pack msg
   SPCT.SourceLocation srcLoc -> Just $ SourceLocationData srcLoc
 

--- a/examples/jumpy-jump/app/Main.hs
+++ b/examples/jumpy-jump/app/Main.hs
@@ -21,7 +21,7 @@ withGhcStackProfiler :: IO () -> IO ()
 #ifdef JUMPY_JUMP_USE_GHC_STACK_PROFILER
 withGhcStackProfiler action =
   withRootStackProfiler True $ \manager ->
-    withStackProfiler manager (SampleIntervalMs 1) $
+    withStackProfiler manager (SampleIntervalMs 100) $
       action
 #else
 withGhcStackProfiler action = action


### PR DESCRIPTION
This PR makes the following changes:

- Lower the sample interval in the jumpy-jump example.
- Extract `SymbolTable` to its own module.
- Restructure `ProfilesDictionary`.
- Rename `InfoTable` to `InfoProv`.

These are a few initial steps in a larger reorganisation of profiles support, working towards moving most of the implementation into `eventlog-live` and adding shared IPE and cost-centre databases.