### PR TITLE
Refine testing harness and tests

### DIFF
--- a/eventlog-live-tests/eventlog-live-tests.cabal
+++ b/eventlog-live-tests/eventlog-live-tests.cabal
@@ -42,6 +42,7 @@ common language
     ConstraintKinds
     DataKinds
     DuplicateRecordFields
+    FlexibleContexts
     GADTs
     ImplicitParams
     ImportQualifiedPost
@@ -76,6 +77,8 @@ library
     stm >=2.5 && <2.6,
     tasty >=1.2 && <1.6,
     tasty-hunit >=0.10 && <0.11,
+    temporary >=1.3 && <1.4,
+    text >=1.2 && <2.2,
     vector >=0.11 && <0.14,
 
   if flag(debug)
@@ -98,8 +101,10 @@ test-suite eventlog-live-tests
     base >=4.14 && <5,
     eventlog-live-tests,
     filepath >=1.5 && <1.6,
+    machines >=0.7.4 && <0.8,
     tasty >=1.2 && <1.6,
     temporary >=1.3 && <1.4,
+    text >=1.2 && <2.2,
 
   build-tool-depends:
     eventlog-live-otelcol:eventlog-live-otelcol

--- a/eventlog-live-tests/src/GHC/Eventlog/Live/Test.hs
+++ b/eventlog-live-tests/src/GHC/Eventlog/Live/Test.hs
@@ -5,18 +5,18 @@ module GHC.Eventlog.Live.Test (
   assertResourceTelemetryData,
   hasInput,
 
-  -- * Running an OTLP server
-  ResourceTelemetryData (..),
-  HasOtlpServerInfo,
-  OtlpServerInfo (..),
-  withGrpcOtlpServer,
+  -- * Running `ProgramTest`
+  programTestFor,
 
   -- * Running @eventlog-live-otelcol@
   HasEventlogLiveOtelcolInfo,
   withEventlogLiveOtelcol,
 
-  -- * Running `ProgramTest`
-  programTestFor,
+  -- * Running an OTLP server
+  ResourceTelemetryData (..),
+  HasOtlpServerInfo,
+  OtlpServerInfo (..),
+  withGrpcOtlpServer,
 
   -- * Re-export "GHC.Eventlog.Socket.Test"
   module Export.GEST,
@@ -54,14 +54,47 @@ import System.Process (getCurrentPid)
 import Test.Tasty (TestName)
 import Test.Tasty.HUnit (Assertion)
 
+--------------------------------------------------------------------------------
+-- Running a machine-based assertion on `ResourceTelemetryData`
+--------------------------------------------------------------------------------
+
+{- |
+Assert that any input is received.
+-}
 hasInput :: ProcessT IO i o
 hasInput = construct (await >>= const stop)
 
+{- |
+Run a machine-based assertion on `ResourceTelemetryData`.
+-}
+assertResourceTelemetryData :: (HasLogger, HasTestInfo, HasOtlpServerInfo) => ProcessT IO ResourceTelemetryData x -> Assertion
+assertResourceTelemetryData validateResourceTelemetryData =
+  runT_ $ source ~> logging ~> validateResourceTelemetryData
+ where
+  OtlpServerInfo{..} = ?otlpServerInfo
+  source = repeatedly (yield =<< liftIO next)
+
+logging :: (HasLogger, HasTestInfo, Show i) => ProcessT IO i i
+logging = traversing (\i -> liftIO (debugInfo (show i)) >> pure i)
+
+--------------------------------------------------------------------------------
+-- Running `ProgramTest`
+--------------------------------------------------------------------------------
+
+{- |
+Variant of `GEST.programTestFor` for @eventlog-live-otelcol@ tests.
+
+This variant hides the eventlog socket from the continuation and manages the @eventlog-live-otelcol@ instance and the OTLP server.
+-}
 programTestFor ::
   (HasLogger) =>
+  -- | The test name.
   TestName ->
+  -- | The program to test against.
   Program ->
+  -- | The command-line arguments for @eventlog-live-otelcol@.
   [String] ->
+  -- | The test assertion.
   ((HasTestInfo, HasProgramInfo, HasOtlpServerInfo, HasEventlogLiveOtelcolInfo) => Assertion) ->
   EventlogSocketAddr ->
   ProgramTest
@@ -74,16 +107,13 @@ programTestFor testName program eventlogLiveOtelcolArgs assertion =
       withEventlogLiveOtelcol eventlogLiveOtelcolArgs $
         assertion
 
-assertResourceTelemetryData :: (HasLogger, HasTestInfo, HasOtlpServerInfo) => ProcessT IO ResourceTelemetryData x -> Assertion
-assertResourceTelemetryData validateResourceTelemetryData =
-  runT_ $ source ~> logging ~> validateResourceTelemetryData
- where
-  OtlpServerInfo{..} = ?otlpServerInfo
-  source = repeatedly (yield =<< liftIO next)
+--------------------------------------------------------------------------------
+-- Running @eventlog-live-otelcol@
+--------------------------------------------------------------------------------
 
-logging :: (HasLogger, HasTestInfo, Show i) => ProcessT IO i i
-logging = traversing (\i -> liftIO (debugInfo (show i)) >> pure i)
-
+{- |
+An implicit constraint that requires an @eventlog-live-otelcol@ instance.
+-}
 type HasEventlogLiveOtelcolInfo = (?eventlogLiveOtelcolInfo :: ProgramInfo)
 
 {- |
@@ -125,14 +155,46 @@ withEventlogLiveOtelcol extraArgs action = do
     let ?programInfo = programInfo
     action
 
+--------------------------------------------------------------------------------
+-- Running an OTLP server
+--------------------------------------------------------------------------------
+
+-- NOTE: This type is different from the type with the same name found in
+--       eventlog-live-otelcol, as the latter still uses `OP.ProfileData`.
+--       This should be changed, but requires the refactoring that moves the
+--       profiles machinery into eventlog-live.
+
+{- |
+A batch of resource telemetry data.
+-}
+data ResourceTelemetryData
+  = ResourceTelemetryData'Logs !(Vector OL.ResourceLogs)
+  | ResourceTelemetryData'Metrics !(Vector OM.ResourceMetrics)
+  | ResourceTelemetryData'Profiles !(Vector OP.ResourceProfiles)
+  | ResourceTelemetryData'Spans !(Vector OT.ResourceSpans)
+  deriving (Show)
+
+{- |
+An implicit constraint that requires an OTLP server.
+-}
 type HasOtlpServerInfo = (?otlpServerInfo :: OtlpServerInfo)
 
+{- |
+An instance of an OTLP server.
+
+The `next` field contains an IO action that retrieves the next batch of resource telemetry data.
+
+The `host` and `port` fields contain the information needed to connect to the server.
+-}
 data OtlpServerInfo = OtlpServerInfo
   { next :: IO ResourceTelemetryData
   , host :: HostName
   , port :: PortNumber
   }
 
+{- |
+Run a test with a gRPC OTLP server.
+-}
 withGrpcOtlpServer ::
   (HasLogger, HasTestInfo) =>
   ((HasLogger, HasTestInfo, HasOtlpServerInfo) => IO a) ->
@@ -222,20 +284,7 @@ withGrpcOtlpServer action = do
 liftProto :: (Monad m) => (a -> m b) -> G.Proto a -> m (G.Proto b)
 liftProto f pa = G.Proto <$> f (G.getProto pa)
 
---------------------------------------------------------------------------------
--- Code shared with eventlog-live-otelcol
---------------------------------------------------------------------------------
-
--- NOTE: This type is different from the type with the same name found in
---       eventlog-live-otelcol, as the latter still uses `OP.ProfileData`.
---       This should be changed, but requires the refactoring that moves the
---       profiles machinery into eventlog-live.
-data ResourceTelemetryData
-  = ResourceTelemetryData'Logs !(Vector OL.ResourceLogs)
-  | ResourceTelemetryData'Metrics !(Vector OM.ResourceMetrics)
-  | ResourceTelemetryData'Profiles !(Vector OP.ResourceProfiles)
-  | ResourceTelemetryData'Spans !(Vector OT.ResourceSpans)
-  deriving (Show)
+-- TODO: These instances should be shared with eventlog-live-otelcol
 
 type instance G.RequestMetadata (G.Protobuf OLS.LogsService meth) = G.NoMetadata
 type instance G.ResponseInitialMetadata (G.Protobuf OLS.LogsService meth) = G.NoMetadata

--- a/eventlog-live-tests/src/GHC/Eventlog/Live/Test.hs
+++ b/eventlog-live-tests/src/GHC/Eventlog/Live/Test.hs
@@ -4,6 +4,14 @@ module GHC.Eventlog.Live.Test (
   -- * Running a machine-based assertion on `ResourceTelemetryData`
   assertResourceTelemetryData,
   hasInput,
+  hasLogRecordsWith,
+  hasMetricsWith,
+  hasProfilesWith,
+  hasSpansWith,
+  toResourceLogs,
+  toResourceMetrics,
+  toResourceProfiles,
+  toResourceSpans,
 
   -- * Running `ProgramTest`
   programTestFor,
@@ -26,7 +34,7 @@ import Control.Concurrent.STM (newTQueueIO, readTQueue)
 import Control.Concurrent.STM.TQueue (writeTQueue)
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.STM (atomically)
-import Data.Machine (ProcessT, await, construct, repeatedly, runT_, stop, traversing, yield, (~>))
+import Data.Machine (ProcessT, asParts, await, construct, filtered, mapping, repeatedly, runT_, stop, traversing, yield, (~>))
 import Data.Vector (Vector)
 import Data.Vector qualified as V
 import GHC.Eventlog.Socket.Test as Export.GEST hiding (programTestFor)
@@ -47,9 +55,14 @@ import Proto.Opentelemetry.Proto.Collector.Profiles.V1development.ProfilesServic
 import Proto.Opentelemetry.Proto.Collector.Trace.V1.TraceService qualified as OTS
 import Proto.Opentelemetry.Proto.Collector.Trace.V1.TraceService_Fields qualified as OTS
 import Proto.Opentelemetry.Proto.Logs.V1.Logs qualified as OL
+import Proto.Opentelemetry.Proto.Logs.V1.Logs_Fields qualified as OL
 import Proto.Opentelemetry.Proto.Metrics.V1.Metrics qualified as OM
+import Proto.Opentelemetry.Proto.Metrics.V1.Metrics_Fields qualified as OM
 import Proto.Opentelemetry.Proto.Profiles.V1development.Profiles qualified as OP
+import Proto.Opentelemetry.Proto.Profiles.V1development.Profiles_Fields qualified as OP
+import Proto.Opentelemetry.Proto.Trace.V1.Trace qualified as OS
 import Proto.Opentelemetry.Proto.Trace.V1.Trace qualified as OT
+import Proto.Opentelemetry.Proto.Trace.V1.Trace_Fields qualified as OS
 import System.Process (getCurrentPid)
 import Test.Tasty (TestName)
 import Test.Tasty.HUnit (Assertion)
@@ -61,8 +74,104 @@ import Test.Tasty.HUnit (Assertion)
 {- |
 Assert that any input is received.
 -}
-hasInput :: ProcessT IO i o
+hasInput :: (Monad m) => ProcessT m i o
 hasInput = construct (await >>= const stop)
+
+{- |
+Assert that log records with the given property are received.
+-}
+hasLogRecordsWith :: (Monad m) => (OL.LogRecord -> Bool) -> ProcessT m ResourceTelemetryData x
+hasLogRecordsWith f =
+  toResourceLogs
+    ~> asParts
+    ~> mapping (^. OL.vec'scopeLogs)
+    ~> asParts
+    ~> mapping (^. OL.vec'logRecords)
+    ~> asParts
+    ~> filtered f
+    ~> hasInput
+
+{- |
+Assert that metrics with the given property are received.
+-}
+hasMetricsWith :: (Monad m) => (OM.Metric -> Bool) -> ProcessT m ResourceTelemetryData x
+hasMetricsWith f =
+  toResourceMetrics
+    ~> asParts
+    ~> mapping (^. OM.vec'scopeMetrics)
+    ~> asParts
+    ~> mapping (^. OM.vec'metrics)
+    ~> asParts
+    ~> filtered f
+    ~> hasInput
+
+{- |
+Assert that metrics with the given property are received.
+-}
+hasProfilesWith :: (Monad m) => (OP.Profile -> Bool) -> ProcessT m ResourceTelemetryData x
+hasProfilesWith f =
+  toResourceProfiles
+    ~> asParts
+    ~> mapping (^. OP.vec'scopeProfiles)
+    ~> asParts
+    ~> mapping (^. OP.vec'profiles)
+    ~> asParts
+    ~> filtered f
+    ~> hasInput
+
+{- |
+Assert that metrics with the given property are received.
+-}
+hasSpansWith :: (Monad m) => (OS.Span -> Bool) -> ProcessT m ResourceTelemetryData x
+hasSpansWith f =
+  toResourceSpans
+    ~> asParts
+    ~> mapping (^. OS.vec'scopeSpans)
+    ~> asParts
+    ~> mapping (^. OS.vec'spans)
+    ~> asParts
+    ~> filtered f
+    ~> hasInput
+
+{- |
+Filter a resource telemetry stream to just batches of resource logs.
+-}
+toResourceLogs :: (Monad m) => ProcessT m ResourceTelemetryData (Vector OL.ResourceLogs)
+toResourceLogs =
+  repeatedly $
+    await >>= \case
+      ResourceTelemetryData'Logs logs -> yield logs
+      _otherwise -> pure ()
+
+{- |
+Filter a resource telemetry stream to just batches of resource metrics.
+-}
+toResourceMetrics :: (Monad m) => ProcessT m ResourceTelemetryData (Vector OM.ResourceMetrics)
+toResourceMetrics =
+  repeatedly $
+    await >>= \case
+      ResourceTelemetryData'Metrics metrics -> yield metrics
+      _otherwise -> pure ()
+
+{- |
+Filter a resource telemetry stream to just batches of resource profiles.
+-}
+toResourceProfiles :: (Monad m) => ProcessT m ResourceTelemetryData (Vector OP.ResourceProfiles)
+toResourceProfiles =
+  repeatedly $
+    await >>= \case
+      ResourceTelemetryData'Profiles profiles -> yield profiles
+      _otherwise -> pure ()
+
+{- |
+Filter a resource telemetry stream to just batches of resource spans.
+-}
+toResourceSpans :: (Monad m) => ProcessT m ResourceTelemetryData (Vector OT.ResourceSpans)
+toResourceSpans =
+  repeatedly $
+    await >>= \case
+      ResourceTelemetryData'Spans spans -> yield spans
+      _otherwise -> pure ()
 
 {- |
 Run a machine-based assertion on `ResourceTelemetryData`.

--- a/eventlog-live-tests/src/GHC/Eventlog/Live/Test.hs
+++ b/eventlog-live-tests/src/GHC/Eventlog/Live/Test.hs
@@ -1,22 +1,36 @@
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module GHC.Eventlog.Live.Test (
   -- * Running a machine-based assertion on `ResourceTelemetryData`
   assertResourceTelemetryData,
   hasInput,
-  hasLogRecordsWith,
-  hasMetricsWith,
-  hasProfilesWith,
-  hasSpansWith,
+  withLogRecord'body,
+  toLogRecords,
+  withMetric'name,
+  toMetrics,
+  toProfiles,
+  toSpans,
+  withScope,
+  toScopeLogs,
+  toScopeMetrics,
+  toScopeProfiles,
+  toScopeSpans,
+  withServiceName,
+  withResource,
   toResourceLogs,
   toResourceMetrics,
   toResourceProfiles,
   toResourceSpans,
+  logging,
 
   -- * Running `ProgramTest`
   programTestFor,
 
   -- * Running @eventlog-live-otelcol@
+  EventlogLiveOtelcolOptions (extraArgs, maybeConfigBody),
+  defaultOptions,
   HasEventlogLiveOtelcolInfo,
   withEventlogLiveOtelcol,
 
@@ -32,13 +46,17 @@ module GHC.Eventlog.Live.Test (
 
 import Control.Concurrent.STM (newTQueueIO, readTQueue)
 import Control.Concurrent.STM.TQueue (writeTQueue)
+import Control.Monad ((<=<))
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.STM (atomically)
+import Data.Foldable (find, traverse_)
 import Data.Machine (ProcessT, asParts, await, construct, filtered, mapping, repeatedly, runT_, stop, traversing, yield, (~>))
+import Data.Text (Text)
 import Data.Vector (Vector)
 import Data.Vector qualified as V
 import GHC.Eventlog.Socket.Test as Export.GEST hiding (programTestFor)
 import GHC.Eventlog.Socket.Test qualified as GEST (programTestFor)
+import GHC.Exts (Proxy#, proxy#)
 import Network.GRPC.Common qualified as G
 import Network.GRPC.Common.Protobuf ((^.))
 import Network.GRPC.Common.Protobuf qualified as G
@@ -54,15 +72,21 @@ import Proto.Opentelemetry.Proto.Collector.Profiles.V1development.ProfilesServic
 import Proto.Opentelemetry.Proto.Collector.Profiles.V1development.ProfilesService_Fields qualified as OPS
 import Proto.Opentelemetry.Proto.Collector.Trace.V1.TraceService qualified as OTS
 import Proto.Opentelemetry.Proto.Collector.Trace.V1.TraceService_Fields qualified as OTS
+import Proto.Opentelemetry.Proto.Common.V1.Common qualified as OC
+import Proto.Opentelemetry.Proto.Common.V1.Common_Fields qualified as OC
 import Proto.Opentelemetry.Proto.Logs.V1.Logs qualified as OL
 import Proto.Opentelemetry.Proto.Logs.V1.Logs_Fields qualified as OL
 import Proto.Opentelemetry.Proto.Metrics.V1.Metrics qualified as OM
 import Proto.Opentelemetry.Proto.Metrics.V1.Metrics_Fields qualified as OM
 import Proto.Opentelemetry.Proto.Profiles.V1development.Profiles qualified as OP
 import Proto.Opentelemetry.Proto.Profiles.V1development.Profiles_Fields qualified as OP
+import Proto.Opentelemetry.Proto.Resource.V1.Resource qualified as OR
+import Proto.Opentelemetry.Proto.Resource.V1.Resource_Fields qualified as OR
 import Proto.Opentelemetry.Proto.Trace.V1.Trace qualified as OS
 import Proto.Opentelemetry.Proto.Trace.V1.Trace qualified as OT
 import Proto.Opentelemetry.Proto.Trace.V1.Trace_Fields qualified as OS
+import System.IO qualified as IO
+import System.IO.Temp (withSystemTempFile)
 import System.Process (getCurrentPid)
 import Test.Tasty (TestName)
 import Test.Tasty.HUnit (Assertion)
@@ -78,117 +102,176 @@ hasInput :: (Monad m) => ProcessT m i o
 hasInput = construct (await >>= const stop)
 
 {- |
-Assert that log records with the given property are received.
+Filters a stream of scope telemetry data to only those whose scope satisfies a given predicate.
 -}
-hasLogRecordsWith :: (Monad m) => (OL.LogRecord -> Bool) -> ProcessT m ResourceTelemetryData x
-hasLogRecordsWith f =
-  toResourceLogs
-    ~> asParts
-    ~> mapping (^. OL.vec'scopeLogs)
-    ~> asParts
-    ~> mapping (^. OL.vec'logRecords)
-    ~> asParts
-    ~> filtered f
-    ~> hasInput
+withScope ::
+  forall m s.
+  (Monad m, G.HasField s "maybe'scope" (Maybe OC.InstrumentationScope)) =>
+  (Maybe OC.InstrumentationScope -> Bool) -> ProcessT m s s
+withScope p = filtered (p . maybeScope)
+ where
+  maybeScope :: s -> Maybe OC.InstrumentationScope
+  maybeScope = (^. G.fieldOf (proxy# :: Proxy# "maybe'scope"))
 
 {- |
-Assert that metrics with the given property are received.
+Filters a stream of resource telemetry data to only those for a given service.
 -}
-hasMetricsWith :: (Monad m) => (OM.Metric -> Bool) -> ProcessT m ResourceTelemetryData x
-hasMetricsWith f =
-  toResourceMetrics
-    ~> asParts
-    ~> mapping (^. OM.vec'scopeMetrics)
-    ~> asParts
-    ~> mapping (^. OM.vec'metrics)
-    ~> asParts
-    ~> filtered f
-    ~> hasInput
+withServiceName ::
+  forall m s.
+  (Monad m, G.HasField s "maybe'resource" (Maybe OR.Resource)) =>
+  Text -> ProcessT m s s
+withServiceName serviceName =
+  withResource (maybe False $ (Just serviceName ==) . toServiceName)
+ where
+  toServiceName :: OR.Resource -> Maybe Text
+  toServiceName resource = do
+    let keyIsServiceName = ("service.name" ==) . (^. OC.key)
+    keyValue <- find keyIsServiceName (resource ^. OR.vec'attributes)
+    keyValue ^. OC.value . OC.maybe'stringValue
 
 {- |
-Assert that metrics with the given property are received.
+Filters a stream of resource telemetry data to only those whose resource satisfies a given predicate.
 -}
-hasProfilesWith :: (Monad m) => (OP.Profile -> Bool) -> ProcessT m ResourceTelemetryData x
-hasProfilesWith f =
-  toResourceProfiles
-    ~> asParts
-    ~> mapping (^. OP.vec'scopeProfiles)
-    ~> asParts
-    ~> mapping (^. OP.vec'profiles)
-    ~> asParts
-    ~> filtered f
-    ~> hasInput
+withResource ::
+  forall m s.
+  (Monad m, G.HasField s "maybe'resource" (Maybe OR.Resource)) =>
+  (Maybe OR.Resource -> Bool) -> ProcessT m s s
+withResource p = filtered (p . maybeResource)
+ where
+  maybeResource :: s -> Maybe OR.Resource
+  maybeResource = (^. G.fieldOf (proxy# :: Proxy# "maybe'resource"))
 
 {- |
-Assert that metrics with the given property are received.
+Filters a stream of log records to only those whose body satisfies a given predicate.
 -}
-hasSpansWith :: (Monad m) => (OS.Span -> Bool) -> ProcessT m ResourceTelemetryData x
-hasSpansWith f =
-  toResourceSpans
-    ~> asParts
-    ~> mapping (^. OS.vec'scopeSpans)
-    ~> asParts
-    ~> mapping (^. OS.vec'spans)
-    ~> asParts
-    ~> filtered f
-    ~> hasInput
+withLogRecord'body :: (Monad m) => (Text -> Bool) -> ProcessT m OL.LogRecord OL.LogRecord
+withLogRecord'body p = filtered (maybe False p . ((^. OC.maybe'stringValue) <=< (^. OL.maybe'body)))
 
 {- |
-Filter a resource telemetry stream to just batches of resource logs.
+Stream scope logs as individual log records.
 -}
-toResourceLogs :: (Monad m) => ProcessT m ResourceTelemetryData (Vector OL.ResourceLogs)
+toLogRecords :: (Monad m) => ProcessT m OL.ScopeLogs OL.LogRecord
+toLogRecords = mapping (^. OL.vec'logRecords) ~> asParts
+
+{- |
+Filters a stream of metrics to only those whose name satisfies a given predicate.
+-}
+withMetric'name :: (Monad m) => (Text -> Bool) -> ProcessT m OM.Metric OM.Metric
+withMetric'name p = filtered (p . (^. OM.name))
+
+{- |
+Stream scope metrics as individual metrics.
+-}
+toMetrics :: (Monad m) => ProcessT m OM.ScopeMetrics OM.Metric
+toMetrics = mapping (^. OM.vec'metrics) ~> asParts
+
+{- |
+Stream scope profiles as individual profiles.
+-}
+toProfiles :: (Monad m) => ProcessT m OP.ScopeProfiles OP.Profile
+toProfiles = mapping (^. OP.vec'profiles) ~> asParts
+
+{- |
+Stream scope spans as individual spans.
+-}
+toSpans :: (Monad m) => ProcessT m OS.ScopeSpans OS.Span
+toSpans = mapping (^. OS.vec'spans) ~> asParts
+
+{- |
+Stream resource logs as individual scope logs.
+-}
+toScopeLogs :: (Monad m) => ProcessT m OL.ResourceLogs OL.ScopeLogs
+toScopeLogs = mapping (^. OL.vec'scopeLogs) ~> asParts
+
+{- |
+Stream resource metrics as individual scope metrics.
+-}
+toScopeMetrics :: (Monad m) => ProcessT m OM.ResourceMetrics OM.ScopeMetrics
+toScopeMetrics = mapping (^. OM.vec'scopeMetrics) ~> asParts
+
+{- |
+Stream resource profiles as individual scope profiles.
+-}
+toScopeProfiles :: (Monad m) => ProcessT m OP.ResourceProfiles OP.ScopeProfiles
+toScopeProfiles = mapping (^. OP.vec'scopeProfiles) ~> asParts
+
+{- |
+Stream resource spans as individual scope spans.
+-}
+toScopeSpans :: (Monad m) => ProcessT m OS.ResourceSpans OS.ScopeSpans
+toScopeSpans = mapping (^. OS.vec'scopeSpans) ~> asParts
+
+{- |
+Filter a resource telemetry stream to only resource logs.
+-}
+toResourceLogs :: (Monad m) => ProcessT m ResourceTelemetryData OL.ResourceLogs
 toResourceLogs =
   repeatedly $
     await >>= \case
-      ResourceTelemetryData'Logs logs -> yield logs
+      ResourceTelemetryData'Logs logs -> traverse_ yield logs
       _otherwise -> pure ()
 
 {- |
-Filter a resource telemetry stream to just batches of resource metrics.
+Filter a resource telemetry stream to only resource metrics.
 -}
-toResourceMetrics :: (Monad m) => ProcessT m ResourceTelemetryData (Vector OM.ResourceMetrics)
+toResourceMetrics :: (Monad m) => ProcessT m ResourceTelemetryData OM.ResourceMetrics
 toResourceMetrics =
   repeatedly $
     await >>= \case
-      ResourceTelemetryData'Metrics metrics -> yield metrics
+      ResourceTelemetryData'Metrics metrics -> traverse_ yield metrics
       _otherwise -> pure ()
 
 {- |
-Filter a resource telemetry stream to just batches of resource profiles.
+Filter a resource telemetry stream to only resource profiles.
 -}
-toResourceProfiles :: (Monad m) => ProcessT m ResourceTelemetryData (Vector OP.ResourceProfiles)
+toResourceProfiles :: (Monad m) => ProcessT m ResourceTelemetryData OP.ResourceProfiles
 toResourceProfiles =
   repeatedly $
     await >>= \case
-      ResourceTelemetryData'Profiles profiles -> yield profiles
+      ResourceTelemetryData'Profiles profiles -> traverse_ yield profiles
       _otherwise -> pure ()
 
 {- |
-Filter a resource telemetry stream to just batches of resource spans.
+Filter a resource telemetry stream to only resource spans.
 -}
-toResourceSpans :: (Monad m) => ProcessT m ResourceTelemetryData (Vector OT.ResourceSpans)
+toResourceSpans :: (Monad m) => ProcessT m ResourceTelemetryData OT.ResourceSpans
 toResourceSpans =
   repeatedly $
     await >>= \case
-      ResourceTelemetryData'Spans spans -> yield spans
+      ResourceTelemetryData'Spans spans -> traverse_ yield spans
       _otherwise -> pure ()
 
 {- |
 Run a machine-based assertion on `ResourceTelemetryData`.
 -}
-assertResourceTelemetryData :: (HasLogger, HasTestInfo, HasOtlpServerInfo) => ProcessT IO ResourceTelemetryData x -> Assertion
+assertResourceTelemetryData :: (HasOtlpServerInfo) => ProcessT IO ResourceTelemetryData x -> Assertion
 assertResourceTelemetryData validateResourceTelemetryData =
-  runT_ $ source ~> logging ~> validateResourceTelemetryData
+  runT_ $ source ~> validateResourceTelemetryData
  where
   OtlpServerInfo{..} = ?otlpServerInfo
   source = repeatedly (yield =<< liftIO next)
 
+{- |
+Log each input.
+-}
 logging :: (HasLogger, HasTestInfo, Show i) => ProcessT IO i i
 logging = traversing (\i -> liftIO (debugInfo (show i)) >> pure i)
 
 --------------------------------------------------------------------------------
 -- Running `ProgramTest`
 --------------------------------------------------------------------------------
+
+data EventlogLiveOtelcolOptions = EventlogLiveOtelcolOptions
+  { extraArgs :: [String]
+  , maybeConfigBody :: Maybe String
+  }
+
+defaultOptions :: EventlogLiveOtelcolOptions
+defaultOptions =
+  EventlogLiveOtelcolOptions
+    { extraArgs = []
+    , maybeConfigBody = Nothing
+    }
 
 {- |
 Variant of `GEST.programTestFor` for @eventlog-live-otelcol@ tests.
@@ -202,18 +285,18 @@ programTestFor ::
   -- | The program to test against.
   Program ->
   -- | The command-line arguments for @eventlog-live-otelcol@.
-  [String] ->
+  EventlogLiveOtelcolOptions ->
   -- | The test assertion.
   ((HasTestInfo, HasProgramInfo, HasOtlpServerInfo, HasEventlogLiveOtelcolInfo) => Assertion) ->
   EventlogSocketAddr ->
   ProgramTest
-programTestFor testName program eventlogLiveOtelcolArgs assertion =
+programTestFor testName program eventlogLiveOtelcolOptions assertion =
   GEST.programTestFor testName program (const action)
  where
   action :: (HasTestInfo, HasProgramInfo) => Assertion
   action =
     withGrpcOtlpServer $
-      withEventlogLiveOtelcol eventlogLiveOtelcolArgs $
+      withEventlogLiveOtelcol eventlogLiveOtelcolOptions $
         assertion
 
 --------------------------------------------------------------------------------
@@ -234,10 +317,10 @@ The otelcol socket is automatically configured based on the port in the `OtlpSer
 -}
 withEventlogLiveOtelcol ::
   (HasLogger, HasTestInfo, HasProgramInfo, HasOtlpServerInfo) =>
-  [String] ->
+  EventlogLiveOtelcolOptions ->
   ((HasLogger, HasTestInfo, HasProgramInfo, HasOtlpServerInfo, HasEventlogLiveOtelcolInfo) => IO ()) ->
   IO ()
-withEventlogLiveOtelcol extraArgs action = do
+withEventlogLiveOtelcol eventlogLiveOtelcolOptions action = do
   let programInfo@ProgramInfo{..} = ?programInfo
 
   -- Configure the eventlog socket.
@@ -255,14 +338,29 @@ withEventlogLiveOtelcol extraArgs action = do
   let otelcolArgs =
         ["--otelcol-host=" <> host, "--otelcol-port=" <> show port]
 
-  -- Configure the eventlog-live-otelcol program.
-  let args = extraArgs <> eventlogSocketArgs <> otelcolArgs
-  let eventlogLiveOtelcolProgram = (findProgram "eventlog-live-otelcol"){args = args}
-  withProgramResource (programResource eventlogLiveOtelcolProgram) $ do
-    -- NOTE: By the GHC gods, please let this have the correct semantics.
-    let ?eventlogLiveOtelcolInfo = ?programInfo
-    let ?programInfo = programInfo
-    action
+  -- Create the temporary configuration file, if needed.
+  withTempConfigFile eventlogLiveOtelcolOptions.maybeConfigBody $ \configArgs -> do
+    -- Configure the eventlog-live-otelcol program.
+    let args = eventlogLiveOtelcolOptions.extraArgs <> eventlogSocketArgs <> otelcolArgs <> configArgs
+    let eventlogLiveOtelcolProgram = (findProgram "eventlog-live-otelcol"){args = args}
+    withProgramResource (programResource eventlogLiveOtelcolProgram) $ do
+      -- NOTE: By the GHC gods, please let this have the correct semantics.
+      let ?eventlogLiveOtelcolInfo = ?programInfo
+      let ?programInfo = programInfo
+      action
+
+{- |
+Create a temporary configuration file with the given body, then run the action with access to that file.
+-}
+withTempConfigFile :: Maybe String -> ([String] -> IO a) -> IO a
+withTempConfigFile maybeConfigBody action =
+  case maybeConfigBody of
+    Nothing ->
+      action []
+    Just configBody ->
+      withSystemTempFile "eventlog-live-tests" $ \configFile configHandle -> do
+        IO.hPutStrLn configHandle configBody >> IO.hClose configHandle
+        action ["--config=" <> configFile]
 
 --------------------------------------------------------------------------------
 -- Running an OTLP server

--- a/eventlog-live-tests/tests/Main.hs
+++ b/eventlog-live-tests/tests/Main.hs
@@ -2,7 +2,9 @@
 
 module Main (main) where
 
+import Data.Machine ((~>))
 import Data.Maybe (fromMaybe)
+import Data.Text qualified as T
 import GHC.Eventlog.Live.Test
 import System.Environment (lookupEnv)
 import System.FilePath ((</>))
@@ -29,16 +31,63 @@ main = do
  where
   tests :: (HasLogger) => [EventlogSocketAddr -> ProgramTest]
   tests =
-    [ test_oddball
+    [ test_oddball_HasHeapProfSample
+    , test_oddball_HasUserMarker'Summing
     ]
 
-test_oddball :: (HasLogger) => EventlogSocketAddr -> ProgramTest
-test_oddball =
+test_oddball_HasHeapProfSample :: (HasLogger) => EventlogSocketAddr -> ProgramTest
+test_oddball_HasHeapProfSample =
   let oddball =
         (buildProgram "oddball")
-          { rtsopts = ["-l-au", "-hT", "-A256K", "-i0", "--eventlog-flush-interval=1"]
+          { rtsopts = ["-l-au", "-hT", "--eventlog-flush-interval=1"]
           }
-      eventlogLiveOtelcolArgs = ["-hT", "--eventlog-flush-interval=1"]
-   in programTestFor "test_oddball" oddball eventlogLiveOtelcolArgs $ do
+      options =
+        defaultOptions
+          { extraArgs = ["--service-name=oddball", "-hT", "--eventlog-flush-interval=1"]
+          , maybeConfigBody =
+              Just
+                "processors:\n\
+                \  metrics:\n\
+                \    heap_prof_sample:\n\
+                \      name: ghc_eventlog_HeapProfSample\n\
+                \      description: A heap profile sample.\n\
+                \      aggregate: 1s\n\
+                \      export: 1s\n\
+                \"
+          }
+   in programTestFor "test_oddball_HasHeapProfSample" oddball options $ do
         assertResourceTelemetryData $
-          hasInput
+          toResourceMetrics
+            ~> withServiceName "oddball"
+            ~> toScopeMetrics
+            ~> toMetrics
+            ~> withMetric'name (== "ghc_eventlog_HeapProfSample")
+            ~> hasInput
+
+test_oddball_HasUserMarker'Summing :: (HasLogger) => EventlogSocketAddr -> ProgramTest
+test_oddball_HasUserMarker'Summing =
+  let oddball =
+        (buildProgram "oddball")
+          { rtsopts = ["-l-au", "--eventlog-flush-interval=1"]
+          }
+      options =
+        defaultOptions
+          { extraArgs = ["--service-name=oddball", "--eventlog-flush-interval=1"]
+          , maybeConfigBody =
+              Just
+                "processors:\n\
+                \  logs:\n\
+                \    user_marker:\n\
+                \      name: ghc_eventlog_UserMarker\n\
+                \      description: A user marker.\n\
+                \      export: 1s\n\
+                \"
+          }
+   in programTestFor "test_oddball_HasUserMarker'Summing" oddball options $ do
+        assertResourceTelemetryData $
+          toResourceLogs
+            ~> withServiceName "oddball"
+            ~> toScopeLogs
+            ~> toLogRecords
+            ~> withLogRecord'body ("Summing " `T.isPrefixOf`)
+            ~> hasInput


### PR DESCRIPTION
This PR adds testing combinators to unpack the various pieces of telemetry data and test for the presence of telemetry data with specific types and content (e.g., service name, log record body, metric name, etc).