### PR TITLE
Add HTTP/Protobuf support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Once all containers have started, you can run your own instrumented program toge
 > [!INFO]
 > The `demo/docker-compose-external.yml` configuration _could_ be changed to include an instance of `eventlog-live-otelcol`. However, the instrumented program and `eventlog-live-otelcol` communicate the eventlog over a Unix domain socket and, unfortunately, exposing Unix domain sockets from the host OS to a container is not portable. The `eventlog-socket` library has recently added support for TCP/IPv4 sockets, which _could_ be used to solve this program. However, the eventlog socket is a very high bandwidth socket, so even when support for TCP/IPv4 is added to `eventlog-live-otelcol`, it is likely preferable to continue to use a Unix domain socket.
 
-The `eventlog-live-otelcol` program is intended to analyse the eventlog and send telemetry data to an OpenTelemetry Collector. It supports OTLP over gRPC and HTTP/protobuf. The default is gRPC on port `4317`; pass `--otelcol-protocol=http-protobuf` to use HTTP/protobuf on port `4318`.
+The `eventlog-live-otelcol` program is intended to analyse the eventlog and send telemetry data to an OpenTelemetry Collector. It supports OTLP over gRPC and HTTP/protobuf. The default is gRPC on port `4317`; pass `--otelcol-protocol=http/protobuf` to use HTTP/protobuf on port `4318`.
 
 ## Getting Started
 
@@ -282,7 +282,7 @@ To use it, follow these steps:
       --control-cors-ignore-failure
     ```
 
-    To export using OTLP HTTP/protobuf instead, add `--otelcol-protocol=http-protobuf`. Custom HTTP headers for hosted providers can be supplied with repeatable `--otelcol-header NAME=VALUE` options.
+    To export using OTLP HTTP/protobuf instead, add `--otelcol-protocol=http/protobuf`. Custom HTTP headers for hosted providers can be supplied with repeatable `--otelcol-header NAME=VALUE` options.
 
 ### Fine-tuning `eventlog-live-otelcol`
 

--- a/README.md
+++ b/README.md
@@ -132,8 +132,7 @@ Once all containers have started, you can run your own instrumented program toge
 > [!INFO]
 > The `demo/docker-compose-external.yml` configuration _could_ be changed to include an instance of `eventlog-live-otelcol`. However, the instrumented program and `eventlog-live-otelcol` communicate the eventlog over a Unix domain socket and, unfortunately, exposing Unix domain sockets from the host OS to a container is not portable. The `eventlog-socket` library has recently added support for TCP/IPv4 sockets, which _could_ be used to solve this program. However, the eventlog socket is a very high bandwidth socket, so even when support for TCP/IPv4 is added to `eventlog-live-otelcol`, it is likely preferable to continue to use a Unix domain socket.
 
-> [!WARNING]
-> The `eventlog-live-otelcol` program is intended to analyse the eventlog and send telemetry data to an OpenTelemetry Collector. Currently, only the gRPC protocol is supported. If you wish to send telemetry data to some provider that only supports the HTTP/Protobuf protocol, such as HoneyComb or Grafana Cloud, you must run your own OpenTelemetry Collector and configure that to forward telemetry data to your provider.
+The `eventlog-live-otelcol` program is intended to analyse the eventlog and send telemetry data to an OpenTelemetry Collector. It supports OTLP over gRPC and HTTP/protobuf. The default is gRPC on port `4317`; pass `--otelcol-protocol=http-protobuf` to use HTTP/protobuf on port `4318`.
 
 ## Getting Started
 
@@ -282,6 +281,8 @@ To use it, follow these steps:
       --control-port 30719 \
       --control-cors-ignore-failure
     ```
+
+    To export using OTLP HTTP/protobuf instead, add `--otelcol-protocol=http-protobuf`. Custom HTTP headers for hosted providers can be supplied with repeatable `--otelcol-header NAME=VALUE` options.
 
 ### Fine-tuning `eventlog-live-otelcol`
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Once all containers have started, you can run your own instrumented program toge
 > [!INFO]
 > The `demo/docker-compose-external.yml` configuration _could_ be changed to include an instance of `eventlog-live-otelcol`. However, the instrumented program and `eventlog-live-otelcol` communicate the eventlog over a Unix domain socket and, unfortunately, exposing Unix domain sockets from the host OS to a container is not portable. The `eventlog-socket` library has recently added support for TCP/IPv4 sockets, which _could_ be used to solve this program. However, the eventlog socket is a very high bandwidth socket, so even when support for TCP/IPv4 is added to `eventlog-live-otelcol`, it is likely preferable to continue to use a Unix domain socket.
 
-The `eventlog-live-otelcol` program is intended to analyse the eventlog and send telemetry data to an OpenTelemetry Collector. It supports OTLP over gRPC and HTTP/protobuf. The default is gRPC on port `4317`; pass `--otelcol-protocol=http/protobuf` to use HTTP/protobuf on port `4318`.
+The `eventlog-live-otelcol` program is intended to analyse the eventlog and send telemetry data to an OpenTelemetry Collector. It supports OTLP over gRPC and HTTP/protobuf. The default is gRPC on port `4317`; pass `--otlp-protocol=http/protobuf` to use HTTP/protobuf on port `4318`.
 
 ## Getting Started
 
@@ -276,13 +276,13 @@ To use it, follow these steps:
       --eventlog-socket "$GHC_EVENTLOG_UNIX_PATH" \
       -hT \
       --eventlog-flush-interval=1 \
-      --otelcol-host=localhost \
+      --otlp-endpoint=localhost \
       --control \
       --control-port 30719 \
       --control-cors-ignore-failure
     ```
 
-    To export using OTLP HTTP/protobuf instead, add `--otelcol-protocol=http/protobuf`. Custom HTTP headers for hosted providers can be supplied with repeatable `--otelcol-header NAME=VALUE` options.
+    To export using the OTLP HTTP/Protobuf protocol, pass `--otlp-protocol=http/protobuf`. Additional headers may be provided with `--otlp-http-headers` as, e.g., `--otlp-http-headers=api-key=key,other-config-value=value`.
 
 ### Fine-tuning `eventlog-live-otelcol`
 

--- a/demo-http-protobuf/Dockerfile.eventlog-live-otelcol
+++ b/demo-http-protobuf/Dockerfile.eventlog-live-otelcol
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1.7-labs
+
+# To build this image, run:
+# docker build --tag well-typed/eventlog-live-otelcol:0.1.0.0 --file ./demo/Dockerfile.eventlog-live-otelcol .
+
+# Use the Haskell image with GHC 9.10.1
+# See: https://hub.docker.com/_/haskell
+FROM haskell:9.10-slim-bullseye AS build
+
+# Copy required packages to container
+WORKDIR "/eventlog-live"
+COPY --parents \
+  "./eventlog-live-otelcol/" \
+  "./eventlog-live/" \
+  "/eventlog-live/"
+
+# Create cabal.project file
+COPY <<EOF /eventlog-live/cabal.project
+packages: eventlog-live
+packages: eventlog-live-otelcol
+
+-- 2025-11-17:
+-- disable snappy support in grpc-spec
+package grpc-spec
+  flags: -snappy
+
+-- 2026-06-24:
+-- disable io_uring support in blockio
+package blockio
+  flags: +serialblockio
+EOF
+
+# Install protoc
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y protobuf-compiler
+
+# Build eventlog-live-otelcol
+RUN <<EOF
+cabal update
+mkdir "/eventlog-live/bin"
+cabal install \
+    -f+control \
+    --overwrite-policy=always \
+    --install-method=copy \
+    --installdir="/eventlog-live/bin" \
+    eventlog-live-otelcol
+EOF
+
+# Copy eventlog-live-otelcol to output stage
+FROM debian:bullseye-slim AS output
+COPY --from=build "/eventlog-live/bin/eventlog-live-otelcol" "/bin/eventlog-live-otelcol"
+
+# Run command
+ENTRYPOINT ["/bin/eventlog-live-otelcol"]

--- a/demo-http-protobuf/Dockerfile.oddball
+++ b/demo-http-protobuf/Dockerfile.oddball
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.7-labs
+
+# To build this image, run:
+# docker build --tag well-typed/eventlog-live-example-oddball:0.1.0.0 --file ./demo/Dockerfile.oddball .
+
+# Use the Haskell image with GHC 9.12.2
+# See: https://hub.docker.com/_/haskell
+FROM haskell:9.12-slim-bookworm AS build
+
+# Configure oddball
+ARG GHC_EVENTLOG_UNIX_PATH: "/tmp/ghc_eventlog.sock"
+
+# Copy files from the project directory
+WORKDIR "/eventlog-live/examples/oddball"
+COPY --parents \
+    "./examples/oddball/" \
+    "/eventlog-live/"
+
+# Create cabal.project file
+COPY <<EOF /eventlog-live/examples/oddball/cabal.project
+packages: .
+EOF
+
+# Build oddball
+RUN <<EOF
+cabal update
+mkdir "/eventlog-live/bin"
+cabal install \
+    --constraint="eventlog-socket +control" \
+    --overwrite-policy=always \
+    --install-method=copy \
+    --installdir="/eventlog-live/bin" \
+    oddball
+EOF
+
+# Copy oddball to output stage
+FROM debian:bookworm-slim AS output
+COPY --from=build "/eventlog-live/bin/oddball" "/bin/oddball"
+ENTRYPOINT ["/bin/oddball"]

--- a/demo-http-protobuf/README.md
+++ b/demo-http-protobuf/README.md
@@ -1,0 +1,14 @@
+# Dockerfiles for `eventlog-live-otelcol`
+
+This directory contains example containers for use with `eventlog-live-otelcol`.
+
+The `docker-compose.yml` file contains a self-contained demo using the `oddball` example program.
+
+The `docker-compose-external.yml` file contains the applications needed to store and visualise eventlog data from an external program.
+This requires running the external program side-by-side with `eventlog-live-otelcol` as is done in, e.g., `examples/oddball/oddball-otelcol-with-hT.sh`.
+
+> [!NOTE]
+> These Docker Compose files pin an older version of Tempo, as the current version does not appear to respect `target: all`.
+> Unfortunately, `grafana/tempo` does not pin versions, but only pins commits _with_ the architecture of the image.
+> If you're on a machine with a x86_64 or AMD64 architecture, the default provided in the files works for you.
+> If you're on a machine with an ARM64 or AArch64 architecture, you should run these Docker Compose files with `ARCH=arm64`.

--- a/demo-http-protobuf/config/eventlog-live-otelcol.yaml
+++ b/demo-http-protobuf/config/eventlog-live-otelcol.yaml
@@ -1,0 +1,78 @@
+processors:
+  logs:
+    thread_label:
+      name: ghc_eventlog_ThreadLabel
+      description: A thread label.
+      export: false
+    user_marker:
+      name: ghc_eventlog_UserMarker
+      description: A user marker.
+      export: false
+    user_message:
+      name: ghc_eventlog_UserMessage
+      description: A user log message.
+      export: false
+  metrics:
+    blocks_size:
+      name: ghc_eventlog_BlocksSize
+      description: The current heap size, calculated by the allocated number of blocks.
+      aggregate: 1s
+      export: 5s
+    capability_usage:
+      name: ghc_eventlog_CapabilityUsageDuration
+      description: The duration of each capability usage span.
+      aggregate: 1s
+      export: 5s
+    heap_allocated:
+      name: ghc_eventlog_HeapAllocated
+      description: The size of a newly allocated chunk of heap.
+      aggregate: 1s
+      export: 5s
+    heap_live:
+      name: ghc_eventlog_HeapLive
+      description: The current heap size, calculated by the allocated number of megablocks.
+      aggregate: 1s
+      export: 5s
+    heap_prof_sample:
+      name: ghc_eventlog_HeapProfSample
+      description: A heap profile sample.
+      aggregate: 1s
+      export: 5s
+    heap_size:
+      name: ghc_eventlog_HeapSize
+      description: The current heap size, calculated by the allocated number of megablocks.
+      aggregate: 1s
+      export: 5s
+    mem_current:
+      name: ghc_eventlog_MemCurrent
+      description: The number of megablocks currently allocated.
+      aggregate: 1s
+      export: 5s
+    mem_needed:
+      name: ghc_eventlog_MemNeeded
+      description: The number of megablocks currently needed.
+      aggregate: 1s
+      export: 5s
+    mem_returned:
+      name: ghc_eventlog_MemReturned
+      description: The number of megablocks currently being returned to the OS.
+      aggregate: 1s
+      export: 5s
+  traces:
+    capability_usage:
+      name: ghc_eventlog_CapabilityUsage
+      description: A trace of capability usage (either mutator thread or garbage collection).
+      export: false
+    thread_state:
+      name: ghc_eventlog_ThreadState
+      description: A trace of thread state changes (either running or stopped).
+      export: false
+  profiles:
+    call_stack_profile:
+      name: ghc_eventlog_CallStackProfile
+      description: A GHC call-stack profile.
+      export: false
+    cost_centre_stack_profile:
+      name: ghc_eventlog_CostCentreStackProfile
+      description: A GHC cost-centre stack profile.
+      export: false

--- a/demo-http-protobuf/config/eventlog-live-otelcol.yaml
+++ b/demo-http-protobuf/config/eventlog-live-otelcol.yaml
@@ -18,16 +18,20 @@ processors:
       description: The current heap size, calculated by the allocated number of blocks.
       aggregate: 1s
       export: 5s
+    # 2026-07-24:
+    # Prometheus does not appear to support sums with a delta aggregration temporality.
     capability_usage:
       name: ghc_eventlog_CapabilityUsageDuration
       description: The duration of each capability usage span.
       aggregate: 1s
-      export: 5s
+      export: false
+    # 2026-07-24:
+    # Prometheus does not appear to support sums with a delta aggregration temporality.
     heap_allocated:
       name: ghc_eventlog_HeapAllocated
       description: The size of a newly allocated chunk of heap.
       aggregate: 1s
-      export: 5s
+      export: false
     heap_live:
       name: ghc_eventlog_HeapLive
       description: The current heap size, calculated by the allocated number of megablocks.

--- a/demo-http-protobuf/config/grafana-dashboards.yaml
+++ b/demo-http-protobuf/config/grafana-dashboards.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+providers:
+  - name: Dashboards
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: true

--- a/demo-http-protobuf/config/grafana-dashboards/heap-profiles.json
+++ b/demo-http-protobuf/config/grafana-dashboards/heap-profiles.json
@@ -1,0 +1,1195 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "a1d17d5b-a204-49b7-83a5-8d56afc7424b",
+    "namespace": "default",
+    "uid": "8d5a5c56-de28-48d3-8be9-a5a200111e2d",
+    "resourceVersion": "1784291505929996",
+    "generation": 1,
+    "creationTimestamp": "2026-07-17T12:31:45Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "1935882724188160"
+    },
+    "annotations": {
+      "grafana.app/createdBy": "access-policy:service",
+      "grafana.app/managedBy": "classic-file-provisioning",
+      "grafana.app/managerId": "Dashboards",
+      "grafana.app/sourceChecksum": "0b0e1b22aaef997c49c0638b4fad8f76",
+      "grafana.app/sourcePath": "/var/lib/grafana/dashboards/heap-profiles.json",
+      "grafana.app/sourceTimestamp": "1784291387000",
+      "grafana.app/folder": ""
+    }
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "query": {
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {},
+            "version": "v0"
+          }
+        }
+      },
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "enable": false,
+          "filter": {
+            "exclude": true,
+            "ids": [5]
+          },
+          "hide": false,
+          "iconColor": "red",
+          "legacyOptions": {
+            "expr": "{service_name=\"${service_name}\"} |~ `${user_marker_filter}` | kind = `UserMarker`",
+            "queryType": "range"
+          },
+          "name": "UserMarker",
+          "query": {
+            "datasource": {
+              "name": "P8E80F9AEF21F6940"
+            },
+            "group": "loki",
+            "kind": "DataQuery",
+            "spec": {},
+            "version": "v0"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PBFA97CFB590B2093"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "builder",
+                        "expr": "avg(ghc_eventlog_HeapSize_bytes{exported_job=\"$service_name\"})",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "HeapSize",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "HeapSize"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PBFA97CFB590B2093"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "builder",
+                        "expr": "avg(ghc_eventlog_BlocksSize_bytes{exported_job=\"$service_name\"})",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "instant": false,
+                        "legendFormat": "BlocksSize",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "BlockSize"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PBFA97CFB590B2093"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "builder",
+                        "expr": "avg(ghc_eventlog_HeapLive_bytes{exported_job=\"$service_name\"})",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "instant": false,
+                        "legendFormat": "HeapLive",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "HeapLive"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 1,
+          "links": [],
+          "title": "Heap Size for ${service_name}",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": 3600000,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.1.0"
+          }
+        }
+      },
+      "panel-11": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "builder",
+                        "expr": "",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 11,
+          "links": [],
+          "title": "",
+          "transparent": true,
+          "vizConfig": {
+            "group": "canvas",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "inlineEditing": false,
+                "panZoom": false,
+                "root": {
+                  "background": {
+                    "color": {
+                      "fixed": "transparent"
+                    }
+                  },
+                  "border": {
+                    "color": {
+                      "fixed": "dark-green"
+                    }
+                  },
+                  "constraint": {
+                    "horizontal": "left",
+                    "vertical": "top"
+                  },
+                  "elements": [
+                    {
+                      "background": {
+                        "color": {
+                          "fixed": "transparent"
+                        }
+                      },
+                      "border": {
+                        "color": {
+                          "fixed": "dark-green"
+                        }
+                      },
+                      "config": {
+                        "align": "center",
+                        "api": {
+                          "contentType": "application/x-www-form-urlencoded",
+                          "data": "service-name=${service_name}",
+                          "endpoint": "http://localhost:30719/control/eventlog-socket/request-heap-census",
+                          "headerParams": [],
+                          "method": "POST",
+                          "queryParams": [],
+                          "successMessage": "Requested Heap Census"
+                        },
+                        "color": {
+                          "fixed": "#F0F4FD"
+                        },
+                        "size": 14,
+                        "style": {
+                          "variant": "destructive"
+                        },
+                        "text": {
+                          "fixed": "Census",
+                          "mode": "fixed"
+                        }
+                      },
+                      "constraint": {
+                        "horizontal": "left",
+                        "vertical": "top"
+                      },
+                      "name": "RequestHeapCensus",
+                      "placement": {
+                        "height": 30,
+                        "left": 300,
+                        "rotation": 0,
+                        "top": 0,
+                        "width": 90
+                      },
+                      "type": "button"
+                    },
+                    {
+                      "background": {
+                        "color": {
+                          "fixed": "transparent"
+                        }
+                      },
+                      "border": {
+                        "color": {
+                          "fixed": "dark-green"
+                        }
+                      },
+                      "config": {
+                        "align": "center",
+                        "api": {
+                          "contentType": "application/x-www-form-urlencoded",
+                          "data": "service-name=${service_name}",
+                          "endpoint": "http://localhost:30719/control/eventlog-socket/stop-heap-profiling",
+                          "headerParams": [],
+                          "method": "POST",
+                          "queryParams": [],
+                          "successMessage": "Requested Heap Profiling Stop"
+                        },
+                        "color": {
+                          "fixed": "#F0F4FD"
+                        },
+                        "size": 14,
+                        "style": {
+                          "variant": "destructive"
+                        },
+                        "text": {
+                          "fixed": "Stop",
+                          "mode": "fixed"
+                        }
+                      },
+                      "constraint": {
+                        "horizontal": "left",
+                        "vertical": "top"
+                      },
+                      "name": "StopHeapProfiling",
+                      "placement": {
+                        "height": 30,
+                        "left": 200,
+                        "rotation": 0,
+                        "top": 0,
+                        "width": 90
+                      },
+                      "type": "button"
+                    },
+                    {
+                      "background": {
+                        "color": {
+                          "fixed": "transparent"
+                        }
+                      },
+                      "border": {
+                        "color": {
+                          "fixed": "dark-green"
+                        },
+                        "width": 0
+                      },
+                      "config": {
+                        "align": "center",
+                        "api": {
+                          "contentType": "application/x-www-form-urlencoded",
+                          "data": "service-name=${service_name}",
+                          "endpoint": "http://localhost:30719/control/eventlog-socket/start-heap-profiling",
+                          "headerParams": [],
+                          "method": "POST",
+                          "queryParams": [],
+                          "successMessage": "Requested Heap Profiling Start"
+                        },
+                        "color": {
+                          "fixed": "#F0F4FD"
+                        },
+                        "size": 14,
+                        "style": {
+                          "variant": "destructive"
+                        },
+                        "text": {
+                          "fixed": "Start",
+                          "mode": "fixed"
+                        }
+                      },
+                      "constraint": {
+                        "horizontal": "left",
+                        "vertical": "top"
+                      },
+                      "name": "StartHeapProfiling",
+                      "placement": {
+                        "height": 30,
+                        "left": 100,
+                        "rotation": 0,
+                        "top": 0,
+                        "width": 90
+                      },
+                      "type": "button"
+                    },
+                    {
+                      "background": {
+                        "color": {
+                          "fixed": "transparent"
+                        }
+                      },
+                      "border": {
+                        "color": {
+                          "fixed": "dark-green"
+                        }
+                      },
+                      "config": {
+                        "align": "right",
+                        "color": {
+                          "fixed": "rgb(204, 204, 220)"
+                        },
+                        "size": 14,
+                        "text": {
+                          "fixed": "Controls"
+                        },
+                        "valign": "middle"
+                      },
+                      "constraint": {
+                        "horizontal": "left",
+                        "vertical": "top"
+                      },
+                      "links": [],
+                      "name": "Label",
+                      "placement": {
+                        "height": 30,
+                        "left": 0,
+                        "rotation": 0,
+                        "top": 0,
+                        "width": 90
+                      },
+                      "type": "text"
+                    }
+                  ],
+                  "name": "Element 1774877699342",
+                  "placement": {
+                    "height": 100,
+                    "left": 0,
+                    "rotation": 0,
+                    "top": 0,
+                    "width": 100
+                  },
+                  "type": "frame"
+                },
+                "showAdvancedTypes": true,
+                "tooltip": {
+                  "disableForOneClick": false,
+                  "mode": "single"
+                },
+                "zoomToContent": false
+              }
+            },
+            "version": "13.1.0"
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PBFA97CFB590B2093"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "builder",
+                        "expr": "sum by(exported_job) (delta(ghc_eventlog_HeapAllocated_bytes_total{exported_job=\"$service_name\"}[$__interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "HeapAllocated",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "HeapAllocated_bytes_delta"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 2,
+          "links": [],
+          "title": "Heap Allocation for ${service_name}",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.1.0"
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PBFA97CFB590B2093"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "builder",
+                        "expr": "avg(ghc_eventlog_MemCurrent{exported_job=\"$service_name\"})",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "Current",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "MemReturn_current"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PBFA97CFB590B2093"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "builder",
+                        "expr": "avg(ghc_eventlog_MemNeeded{exported_job=\"$service_name\"})",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "instant": false,
+                        "legendFormat": "Needed",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "MemReturn_needed"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PBFA97CFB590B2093"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "builder",
+                        "expr": "avg(ghc_eventlog_MemReturned{exported_job=\"$service_name\"})",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "instant": false,
+                        "legendFormat": "Returned",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "MemReturn_returned"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 3,
+          "links": [],
+          "title": "Memory Management for ${service_name}",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": 3600000,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "fieldMinMax": false,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "mblock"
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.1.0"
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PBFA97CFB590B2093"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(ghc_eventlog_HeapProfSample_bytes{exported_job=\"${service_name}\",heapProfBreakdown=\"${heap_prof_breakdown}\"}\nand\ntopk(\n  ${heap_prof_sample_limit},\n  sum_over_time(ghc_eventlog_HeapProfSample_bytes{exported_job=\"${service_name}\",heapProfBreakdown=\"${heap_prof_breakdown}\"}[${__range}] @ ${__to:date:seconds})\n))\nor\nsum by(exported_job) ((ghc_eventlog_HeapProfSample_bytes{exported_job=\"${service_name}\",heapProfBreakdown=\"${heap_prof_breakdown}\"}\nunless\ntopk(\n  ${heap_prof_sample_limit},\n  sum_over_time(ghc_eventlog_HeapProfSample_bytes{exported_job=\"${service_name}\",heapProfBreakdown=\"${heap_prof_breakdown}\"}[${__range}] @ ${__to:date:seconds})\n)))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "instant": false,
+                        "legendFormat": "{{heapProfLabel}}\\{{ipName}}",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "group": "renameByRegex",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "regex": "^(0x[0-9a-f]+\\\\)?([^\\\\]*)(\\\\?)$",
+                      "renamePattern": "$2"
+                    }
+                  }
+                },
+                {
+                  "group": "renameByRegex",
+                  "kind": "Transformation",
+                  "spec": {
+                    "options": {
+                      "regex": "^\\\\$",
+                      "renamePattern": "Other"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 4,
+          "links": [],
+          "title": "Heap Profile for ${service_name}",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 100,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": 3600000,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "fieldMinMax": false,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": true,
+                  "maxWidth": 800,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "13.1.0"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "TabsLayout",
+      "spec": {
+        "tabs": [
+          {
+            "kind": "TabsLayoutTab",
+            "spec": {
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-4"
+                        },
+                        "height": 27,
+                        "width": 12,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-1"
+                        },
+                        "height": 9,
+                        "width": 12,
+                        "x": 12,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-3"
+                        },
+                        "height": 9,
+                        "width": 12,
+                        "x": 12,
+                        "y": 9
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-2"
+                        },
+                        "height": 10,
+                        "width": 12,
+                        "x": 12,
+                        "y": 18
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-11"
+                        },
+                        "height": 1,
+                        "width": 12,
+                        "x": 0,
+                        "y": 27
+                      }
+                    }
+                  ]
+                }
+              },
+              "repeat": {
+                "mode": "variable",
+                "value": "service_name"
+              },
+              "title": "${service_name}",
+              "variables": [
+                {
+                  "kind": "TextVariable",
+                  "spec": {
+                    "current": {
+                      "text": "10",
+                      "value": "10"
+                    },
+                    "description": "The Heap Profile visualisation shows the largest samples up to this limit and summarises all other samples as Other.",
+                    "hide": "dontHide",
+                    "label": "Heap Profile Sample Limit",
+                    "name": "heap_prof_sample_limit",
+                    "query": "10",
+                    "skipUrlSync": false
+                  }
+                },
+                {
+                  "kind": "QueryVariable",
+                  "spec": {
+                    "allowCustomValue": true,
+                    "current": {
+                      "text": "-hT",
+                      "value": "-hT"
+                    },
+                    "definition": "label_values(ghc_eventlog_HeapProfSample_bytes{exported_job=\"$service_name\"},heapProfBreakdown)",
+                    "hide": "dontHide",
+                    "includeAll": false,
+                    "label": "Heap Profile Breakdown",
+                    "multi": false,
+                    "name": "heap_prof_breakdown",
+                    "options": [],
+                    "query": {
+                      "datasource": {
+                        "name": "PBFA97CFB590B2093"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "qryType": 1,
+                        "query": "label_values(ghc_eventlog_HeapProfSample_bytes{exported_job=\"$service_name\"},heapProfBreakdown)",
+                        "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                      },
+                      "version": "v0"
+                    },
+                    "refresh": "onDashboardLoad",
+                    "regex": "",
+                    "regexApplyTo": "value",
+                    "skipUrlSync": false,
+                    "sort": "disabled"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [],
+    "timeSettings": {
+      "autoRefresh": "5s",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "fiscalYearStartMonth": 0,
+      "from": "now-5m",
+      "hideTimepicker": false,
+      "timezone": "browser",
+      "to": "now"
+    },
+    "title": "Heap Profiles",
+    "variables": [
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "oddball",
+            "value": "oddball"
+          },
+          "definition": "label_values(ghc_eventlog_HeapSize_bytes,exported_job)",
+          "description": "The service name used for the visualisations on this dashboard.",
+          "hide": "dontHide",
+          "includeAll": false,
+          "label": "Service Name",
+          "multi": true,
+          "name": "service_name",
+          "options": [],
+          "query": {
+            "datasource": {
+              "name": "PBFA97CFB590B2093"
+            },
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(ghc_eventlog_HeapSize_bytes,exported_job)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onTimeRangeChanged",
+          "regex": "",
+          "regexApplyTo": "value",
+          "skipUrlSync": false,
+          "sort": "alphabeticalAsc"
+        }
+      },
+      {
+        "kind": "TextVariable",
+        "spec": {
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "description": "A regular expression to filter the user markers.",
+          "hide": "dontHide",
+          "label": "Filter UserMarker",
+          "name": "user_marker_filter",
+          "query": "",
+          "skipUrlSync": false
+        }
+      }
+    ]
+  }
+}

--- a/demo-http-protobuf/config/grafana-datasources.yaml
+++ b/demo-http-protobuf/config/grafana-datasources.yaml
@@ -1,0 +1,18 @@
+apiVersion: 1
+datasources:
+  - name: Loki
+    type: loki
+    acess: proxy
+    url: http://loki:3100
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+  - name: Pyroscope
+    type: grafana-pyroscope-datasource
+    access: proxy
+    url: http://pyroscope:4040

--- a/demo-http-protobuf/config/prometheus.yaml
+++ b/demo-http-protobuf/config/prometheus.yaml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 1s
+
+scrape_configs:
+  - job_name: "otelcol"
+    static_configs:
+      - targets: ["otelcol:9090"]

--- a/demo-http-protobuf/docker-compose.yml
+++ b/demo-http-protobuf/docker-compose.yml
@@ -1,0 +1,81 @@
+services:
+  oddball:
+    # container_name: oddball
+    build:
+      context: ".."
+      dockerfile: "./demo-http-protobuf/Dockerfile.oddball"
+    volumes:
+      - "oddball:/run/oddball"
+    environment:
+      GHC_EVENTLOG_UNIX_PATH: "/run/oddball/ghc_eventlog.sock"
+      LANG: C.UTF-8
+    command:
+      - "+RTS"
+      - "-l"
+      - "-hT"
+      - "--eventlog-flush-interval=1"
+      - "-RTS"
+
+  eventlog-live-otelcol:
+    # container_name: eventlog-live-otelcol
+    build:
+      context: ".."
+      dockerfile: "./demo-http-protobuf/Dockerfile.eventlog-live-otelcol"
+    depends_on:
+      oddball:
+        condition: "service_started"
+      prometheus:
+        condition: "service_started"
+    ports:
+      - "30719:30719"
+    healthcheck:
+      test: "curl -f http://localhost:30719/health"
+      interval: 1m
+      timeout: 10s
+      retries: 5
+    volumes:
+      - "oddball:/run/oddball"
+      - "./config/eventlog-live-otelcol.yaml:/etc/eventlog-live-otelcol/config.yaml"
+    environment:
+      LANG: C.UTF-8
+    command:
+      - "--verbosity=debug"
+      - "--config=/etc/eventlog-live-otelcol/config.yaml"
+      - "--service-name=oddball"
+      - "--eventlog-socket=/run/oddball/ghc_eventlog.sock"
+      - "-hT"
+      - "--eventlog-flush-interval=1"
+      - "--otlp-protocol=http/protobuf"
+      - "--otlp-endpoint=http://prometheus:9090/api/v1/otlp"
+      - "--control"
+      - "--control-port=30719"
+      - "--control-cors-ignore-failure"
+
+  grafana:
+    # container_name: grafana
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    healthcheck:
+      test: "curl -f http://localhost:3000/api/health"
+      interval: 1m
+      timeout: 10s
+      retries: 5
+    volumes:
+      - "./config/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml"
+      - "./config/grafana-dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml"
+      - "./config/grafana-dashboards:/var/lib/grafana/dashboards"
+
+  prometheus:
+    # container_name: prometheus
+    image: prom/prometheus:latest
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yaml"
+      - "--web.enable-otlp-receiver"
+    volumes:
+      - "./config/prometheus.yaml:/etc/prometheus/prometheus.yaml"
+    ports:
+      - "9090:9090" # Prometheus
+
+volumes:
+  oddball:

--- a/demo-nix/configuration.nix
+++ b/demo-nix/configuration.nix
@@ -101,7 +101,7 @@ in
         Type = "simple";
         User = "eventlog";
         Group = "eventlog";
-        ExecStart = "${eventlog-live-otelcol}/bin/eventlog-live-otelcol --service-name=oddball --eventlog-socket=/run/ghc-eventlog-socket/ghc-eventlog.sock --otelcol-host=0.0.0.0 --otelcol-port=4317";
+        ExecStart = "${eventlog-live-otelcol}/bin/eventlog-live-otelcol --service-name=oddball --eventlog-socket=/run/ghc-eventlog-socket/ghc-eventlog.sock --otlp-endpoint=0.0.0.0:4317";
         Restart = "always";
         RestartSec = 5;
       };

--- a/demo/Dockerfile.eventlog-live-otelcol
+++ b/demo/Dockerfile.eventlog-live-otelcol
@@ -31,7 +31,7 @@ package blockio
 EOF
 
 # Install protoc
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y protobuf-compiler libsnappy-dev
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y protobuf-compiler
 
 # Build eventlog-live-otelcol
 RUN <<EOF

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - "--eventlog-socket=/run/oddball/ghc_eventlog.sock"
       - "-hT"
       - "--eventlog-flush-interval=1"
-      - "--otelcol-host=otelcol"
+      - "--otlp-endpoint=otelcol"
       - "--control"
       - "--control-port=30719"
       - "--control-cors-ignore-failure"

--- a/eventlog-live-otelcol/eventlog-live-otelcol.cabal
+++ b/eventlog-live-otelcol/eventlog-live-otelcol.cabal
@@ -5,82 +5,6 @@ synopsis: Stream eventlog data to the OpenTelemetry Collector.
 description:
   This executable supports live streaming of eventlog data into the OpenTelemetry Collector.
 
-  > Usage: eventlog-live-otelcol (--eventlog-stdin | --eventlog-file FILE |
-  >                                --eventlog-socket SOCKET |
-  >                                --eventlog-socket-host HOST
-  >                                --eventlog-socket-port PORT)
-  >                              [--eventlog-socket-timeout SECONDS]
-  >                              [--eventlog-socket-exponent NUMBER]
-  >                              [--eventlog-flush-interval SECONDS]
-  >                              [--eventlog-log-file FILE] [-h Tcmdyrbi]
-  >                              [--service-name STRING]
-  >                              [-v|--verbosity fatal|error|warning|info|debug|trace]
-  >                              [-s|--stats] [--config FILE] --otelcol-host HOST
-  >                              [--otelcol-port PORT] [--otelcol-authority HOST]
-  >                              [--otelcol-ssl] [--otelcol-certificate-store FILE]
-  >                              [--otelcol-ssl-key-log FILE |
-  >                                --otelcol-ssl-key-log-from-env]
-  >                              [--print-defaults] [--print-config-json-schema]
-  >
-  > Available options:
-  >   --eventlog-stdin                  Read the eventlog from stdin.
-  >   --eventlog-file FILE              Read the eventlog from a file.
-  >   --eventlog-socket SOCKET          Read the eventlog from a Unix socket.
-  >   --eventlog-socket-host HOST       Read the eventlog from a TCP/IP socket.
-  >   --eventlog-socket-port PORT       Read the eventlog from a TCP/IP socket.
-  >   --eventlog-socket-timeout SECONDS Eventlog socket connection retry timeout in seconds.
-  >   --eventlog-socket-exponent NUMBER Eventlog socket connection retry timeout exponent.
-  >   --eventlog-flush-interval SECONDS Eventlog flush interval in seconds.
-  >                                     Should match the option passed to the application.
-  >   --eventlog-log-file FILE          Use file to log binary eventlog data.
-  >   -h Tcmdyrbi                       Heap profile breakdown.
-  >                                     Should match the option passed to the application.
-  >   --service-name STRING             The name of the profiled service.
-  >   -v,--verbosity fatal|error|warning|info|debug|trace
-  >                                     The severity threshold for logging.
-  >   -s,--stats                        Display runtime statistics.
-  >   --config FILE                     The path to a detailed configuration file.
-  >   --print-defaults                  Print default configuration options.
-  >   --print-config-json-schema        Print JSON Schema for configuration format.
-  >   --help                            Show this help text.
-  >   --version                         Show version information
-  >
-  > OpenTelemetry Collector Server Options
-  >   --otelcol-host HOST               Otelcol server hostname.
-  >   --otelcol-port PORT               Otelcol server TCP port.
-  >   --otelcol-authority HOST          Otelcol server authority.
-  >   --otelcol-ssl                     Use SSL.
-  >   --otelcol-certificate-store FILE  Store for certificate validation.
-  >   --otelcol-ssl-key-log FILE        Use file to log SSL keys.
-  >   --otelcol-ssl-key-log-from-env    Use SSLKEYLOGFILE to log SSL keys.
-  >
-  > Control Server Options
-  >   --control                         Requires build with -f+control.
-  >                                     Start the control server.
-  >   --control-port                    Requires build with -f+control.
-  >                                     The port number for the control server.
-  >   --control-cors-allow-origin
-  >                                     Requires build with -f+control.
-  >                                     Set the allowed origins for the control server CORS policy.
-  >   --control-cors-max-age            Requires build with -f+control.
-  >                                     Set the maximum age of a cached CORS preflight request for the control server CORS policy.
-  >   --control-cors-require-origin
-  >                                     Requires build with -f+control.
-  >                                     If enabled, the control server will not accept requests without an Origin header.
-  >   --control-cors-ignore-failure
-  >                                     Requires build with -f+control.
-  >                                     If enabled, the control server will accept malformed CORS preflight requests.
-  >
-  > Debug Options
-  >   --my-eventlog-socket-unix         Requires build with -f+use-eventlog-socket.
-  >                                     Open an eventlog socket for this program on the given Unix socket.
-  >   --my-ghc-debug-socket             Requires build with -f+use-ghc-debug-stub.
-  >                                     Open the default ghc-debug socket for this program.
-  >   --my-ghc-debug-socket-unix        Requires build with -f+use-ghc-debug-stub.
-  >                                     Open a ghc-debug Unix domain socket with the given file path.
-  >   --my-ghc-debug-socket-tcp         Requires build with -f+use-ghc-debug-stub.
-  >                                     Open a ghc-debug TCP/IP socket with the given address as 'host:port'.
-
 license: BSD-3-Clause
 license-file: LICENSE
 author: Wen Kokke
@@ -200,6 +124,7 @@ library
     GHC.Eventlog.Live.Otelcol.Config.Default.Raw
     GHC.Eventlog.Live.Otelcol.Config.Types
     GHC.Eventlog.Live.Otelcol.Control
+    GHC.Eventlog.Live.Otelcol.Exporter.Core
     GHC.Eventlog.Live.Otelcol.Exporter.Logs
     GHC.Eventlog.Live.Otelcol.Exporter.Metrics
     GHC.Eventlog.Live.Otelcol.Exporter.Profiles
@@ -234,6 +159,7 @@ library
     ansi-terminal >=1.1 && <1.2,
     base >=4.16 && <4.22,
     bytestring >=0.11 && <0.13,
+    case-insensitive >=1.2 && <1.3,
     containers >=0.6 && <0.8,
     data-default >=0.2 && <0.9,
     dlist >=1.0 && <1.1,
@@ -244,6 +170,9 @@ library
     hashable >=1.4 && <1.6,
     hs-opentelemetry-otlp >=0.2.0 && <0.3,
     HsYAML >=0.2 && <0.3,
+    http-client >=0.7 && <0.8,
+    http-client-tls >=0.3 && <0.4,
+    http-types >=0.12 && <0.13,
     ipedb >=0.2.0.1 && <0.3,
     lens-family >=2.1.3 && <2.2,
     machines >=0.7.4 && <0.8,

--- a/eventlog-live-otelcol/eventlog-live-otelcol.cabal
+++ b/eventlog-live-otelcol/eventlog-live-otelcol.cabal
@@ -163,7 +163,6 @@ library
     case-insensitive >=1.2 && <1.3,
     containers >=0.6 && <0.8,
     data-default >=0.2 && <0.9,
-    deepseq >=1.4 && <1.6,
     dlist >=1.0 && <1.1,
     eventlog-live >=0.5 && <0.6,
     file-embed >=0.0.16 && <0.1,
@@ -187,6 +186,7 @@ library
     text >=1.2 && <2.2,
     transformers >=0.2 && <0.7,
     unordered-containers >=0.2.20 && <0.3,
+    url >=2.1 && <2.2,
     vector >=0.11 && <0.14,
 
   if flag(control)

--- a/eventlog-live-otelcol/eventlog-live-otelcol.cabal
+++ b/eventlog-live-otelcol/eventlog-live-otelcol.cabal
@@ -90,6 +90,7 @@ common language
     DuplicateRecordFields
     FlexibleContexts
     FlexibleInstances
+    FunctionalDependencies
     GADTs
     GeneralizedNewtypeDeriving
     ImportQualifiedPost
@@ -162,6 +163,7 @@ library
     case-insensitive >=1.2 && <1.3,
     containers >=0.6 && <0.8,
     data-default >=0.2 && <0.9,
+    deepseq >=1.4 && <1.6,
     dlist >=1.0 && <1.1,
     eventlog-live >=0.5 && <0.6,
     file-embed >=0.0.16 && <0.1,

--- a/eventlog-live-otelcol/eventlog-live-otelcol.cabal
+++ b/eventlog-live-otelcol/eventlog-live-otelcol.cabal
@@ -177,6 +177,7 @@ library
     ipedb >=0.2.0.1 && <0.3,
     lens-family >=2.1.3 && <2.2,
     machines >=0.7.4 && <0.8,
+    network-uri >=2.6 && <2.8,
     optparse-applicative >=0.17 && <0.20,
     proto-lens >=0.7.1 && <0.8,
     random >=1.2 && <1.4,
@@ -186,7 +187,6 @@ library
     text >=1.2 && <2.2,
     transformers >=0.2 && <0.7,
     unordered-containers >=0.2.20 && <0.3,
-    url >=2.1 && <2.2,
     vector >=0.11 && <0.14,
 
   if flag(control)

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol.hs
@@ -34,7 +34,7 @@ import GHC.Eventlog.Live.Machine.WithStartTime qualified as M
 import GHC.Eventlog.Live.Otelcol.Config qualified as C
 import GHC.Eventlog.Live.Otelcol.Config.Types (FullConfig (..))
 import GHC.Eventlog.Live.Otelcol.Control (ControlServerApi (..), startControlServer)
-import GHC.Eventlog.Live.Otelcol.Exporter.Core (OpenTelemetryExporter, validateOpenTelemetryCollectorOptions, withOpenTelemetryExporter)
+import GHC.Eventlog.Live.Otelcol.Exporter.Core (OtlpExporter, parseOtlpExporterOptions, withOtlpExporter)
 import GHC.Eventlog.Live.Otelcol.Exporter.Logs (exportResourceLogs)
 import GHC.Eventlog.Live.Otelcol.Exporter.Metrics (exportResourceMetrics)
 import GHC.Eventlog.Live.Otelcol.Exporter.Profiles (exportResourceProfiles)
@@ -74,7 +74,7 @@ The main function for @eventlog-live-otelcol@.
 main :: IO ()
 main = do
   Options{..} <- O.execParser options
-  either die pure (validateOpenTelemetryCollectorOptions openTelemetryCollectorOptions)
+  otlpExporterOptions' <- either die pure (parseOtlpExporterOptions otlpExporterOptions)
 
   -- Construct the logging action
   myTelemetryDataChan <- newTChanIO
@@ -198,7 +198,7 @@ main = do
             ~> M.liftTick (asResourceTelemetryData internalResource eventlogLiveScope)
 
     -- Create the full machine to process eventlog data.
-    let processAndExportTelemetry ccdb ipedb openTelemetryExporter =
+    let processAndExportTelemetry ccdb ipedb otlpExporter =
           M.fanoutTick
             [ -- Log a warning if no input has been received after 10 ticks.
               M.validateInput logger 10
@@ -212,7 +212,7 @@ main = do
                 ]
                 ~> M.liftTick asParts
                 -- ...and export it.
-                ~> exportResourceTelemetryData fullConfig openTelemetryExporter
+                ~> exportResourceTelemetryData fullConfig otlpExporter
             ]
             -- Process the statistics
             -- TODO: windowSize should be the maximum of all aggregation and export intervals
@@ -222,7 +222,7 @@ main = do
             ~> M.dropTick
 
     -- Open a connection to the OpenTelemetry Collector.
-    withOpenTelemetryExporter openTelemetryCollectorOptions $ \openTelemetryExporter -> do
+    withOtlpExporter otlpExporterOptions' $ \otlpExporter -> do
       DB.withNewSession def $ \session -> do
         let withCostCentreTable =
               case maybeCCDBPath of
@@ -251,7 +251,7 @@ main = do
                     fullConfig.batchIntervalMs
                     Nothing
                     maybeEventlogLogFile
-                    (processAndExportTelemetry ccdb ipedb openTelemetryExporter)
+                    (processAndExportTelemetry ccdb ipedb otlpExporter)
 
 data TelemetryData
   = TelemetryData'Log OL.LogRecord
@@ -271,9 +271,9 @@ Export resource telemetry data and yield statistics.
 -}
 exportResourceTelemetryData ::
   FullConfig ->
-  OpenTelemetryExporter ->
+  OtlpExporter ->
   ProcessT IO (Tick ResourceTelemetryData) (Tick (DList Stat))
-exportResourceTelemetryData fullConfig openTelemetryExporter =
+exportResourceTelemetryData fullConfig otlpExporter =
   M.fanoutTick
     [ -- Export logs.
       runIf (C.shouldExportLogs fullConfig) $
@@ -283,7 +283,7 @@ exportResourceTelemetryData fullConfig openTelemetryExporter =
           --       making it impossible to not batch once per interval.
           ~> M.batchByTick
           ~> M.liftTick (mapping (toExportLogsServiceRequest . D.toList))
-          ~> exportResourceLogs openTelemetryExporter
+          ~> exportResourceLogs otlpExporter
           ~> M.liftTick (mapping (D.singleton . ExportLogsResultStat))
     , -- Export metrics.
       runIf (C.shouldExportMetrics fullConfig) $
@@ -291,7 +291,7 @@ exportResourceTelemetryData fullConfig openTelemetryExporter =
           -- NOTE: See note above.
           ~> M.batchByTick
           ~> M.liftTick (mapping (toExportMetricsServiceRequest . D.toList))
-          ~> exportResourceMetrics openTelemetryExporter
+          ~> exportResourceMetrics otlpExporter
           ~> M.liftTick (mapping (D.singleton . ExportMetricsResultStat))
     , -- Export spans.
       runIf (C.shouldExportTraces fullConfig) $
@@ -299,12 +299,12 @@ exportResourceTelemetryData fullConfig openTelemetryExporter =
           -- NOTE: See note above.
           ~> M.batchByTick
           ~> M.liftTick (mapping (toExportTracesServiceRequest . D.toList))
-          ~> exportResourceSpans openTelemetryExporter
+          ~> exportResourceSpans otlpExporter
           ~> M.liftTick (mapping (D.singleton . ExportTraceResultStat))
     , -- Export profiles.
       runIf (C.shouldExportProfiles fullConfig) $
         M.liftTick (mapping getResourceProfiles ~> asParts ~> mapping toExportProfileServiceRequest)
-          ~> exportResourceProfiles openTelemetryExporter
+          ~> exportResourceProfiles otlpExporter
           ~> M.liftTick (mapping (D.singleton . ExportProfileResultStat))
     ]
 

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol.hs
@@ -34,6 +34,7 @@ import GHC.Eventlog.Live.Machine.WithStartTime qualified as M
 import GHC.Eventlog.Live.Otelcol.Config qualified as C
 import GHC.Eventlog.Live.Otelcol.Config.Types (FullConfig (..))
 import GHC.Eventlog.Live.Otelcol.Control (ControlServerApi (..), startControlServer)
+import GHC.Eventlog.Live.Otelcol.Exporter.Core (OpenTelemetryExporter, validateOpenTelemetryCollectorOptions, withOpenTelemetryExporter)
 import GHC.Eventlog.Live.Otelcol.Exporter.Logs (exportResourceLogs)
 import GHC.Eventlog.Live.Otelcol.Exporter.Metrics (exportResourceMetrics)
 import GHC.Eventlog.Live.Otelcol.Exporter.Profiles (exportResourceProfiles)
@@ -55,8 +56,6 @@ import IpeDB.Database qualified as DB
 import IpeDB.Types.CostCentre qualified as CC
 import IpeDB.Types.InfoProv qualified as IP
 import Lens.Family2 ((.~))
-import Network.GRPC.Client qualified as G
-import Network.GRPC.Common qualified as G
 import Options.Applicative qualified as O
 import Paths_eventlog_live_otelcol qualified as EventlogLive
 import Proto.Opentelemetry.Proto.Common.V1.Common qualified as OC
@@ -67,6 +66,7 @@ import Proto.Opentelemetry.Proto.Metrics.V1.Metrics_Fields qualified as OM
 import Proto.Opentelemetry.Proto.Profiles.V1development.Profiles qualified as OP
 import Proto.Opentelemetry.Proto.Resource.V1.Resource qualified as OR
 import Proto.Opentelemetry.Proto.Trace.V1.Trace qualified as OT
+import System.Exit (die)
 
 {- |
 The main function for @eventlog-live-otelcol@.
@@ -74,6 +74,7 @@ The main function for @eventlog-live-otelcol@.
 main :: IO ()
 main = do
   Options{..} <- O.execParser options
+  either die pure (validateOpenTelemetryCollectorOptions openTelemetryCollectorOptions)
 
   -- Construct the logging action
   myTelemetryDataChan <- newTChanIO
@@ -197,7 +198,7 @@ main = do
             ~> M.liftTick (asResourceTelemetryData internalResource eventlogLiveScope)
 
     -- Create the full machine to process eventlog data.
-    let processAndExportTelemetry ccdb ipedb conn =
+    let processAndExportTelemetry ccdb ipedb openTelemetryExporter =
           M.fanoutTick
             [ -- Log a warning if no input has been received after 10 ticks.
               M.validateInput logger 10
@@ -211,7 +212,7 @@ main = do
                 ]
                 ~> M.liftTick asParts
                 -- ...and export it.
-                ~> exportResourceTelemetryData fullConfig conn
+                ~> exportResourceTelemetryData fullConfig openTelemetryExporter
             ]
             -- Process the statistics
             -- TODO: windowSize should be the maximum of all aggregation and export intervals
@@ -221,8 +222,7 @@ main = do
             ~> M.dropTick
 
     -- Open a connection to the OpenTelemetry Collector.
-    let OpenTelemetryCollectorOptions{..} = openTelemetryCollectorOptions
-    G.withConnection G.def openTelemetryCollectorServer $ \conn -> do
+    withOpenTelemetryExporter openTelemetryCollectorOptions $ \openTelemetryExporter -> do
       DB.withNewSession def $ \session -> do
         let withCostCentreTable =
               case maybeCCDBPath of
@@ -251,7 +251,7 @@ main = do
                     fullConfig.batchIntervalMs
                     Nothing
                     maybeEventlogLogFile
-                    (processAndExportTelemetry ccdb ipedb conn)
+                    (processAndExportTelemetry ccdb ipedb openTelemetryExporter)
 
 data TelemetryData
   = TelemetryData'Log OL.LogRecord
@@ -271,9 +271,9 @@ Export resource telemetry data and yield statistics.
 -}
 exportResourceTelemetryData ::
   FullConfig ->
-  G.Connection ->
+  OpenTelemetryExporter ->
   ProcessT IO (Tick ResourceTelemetryData) (Tick (DList Stat))
-exportResourceTelemetryData fullConfig connection =
+exportResourceTelemetryData fullConfig openTelemetryExporter =
   M.fanoutTick
     [ -- Export logs.
       runIf (C.shouldExportLogs fullConfig) $
@@ -283,7 +283,7 @@ exportResourceTelemetryData fullConfig connection =
           --       making it impossible to not batch once per interval.
           ~> M.batchByTick
           ~> M.liftTick (mapping (toExportLogsServiceRequest . D.toList))
-          ~> exportResourceLogs connection
+          ~> exportResourceLogs openTelemetryExporter
           ~> M.liftTick (mapping (D.singleton . ExportLogsResultStat))
     , -- Export metrics.
       runIf (C.shouldExportMetrics fullConfig) $
@@ -291,7 +291,7 @@ exportResourceTelemetryData fullConfig connection =
           -- NOTE: See note above.
           ~> M.batchByTick
           ~> M.liftTick (mapping (toExportMetricsServiceRequest . D.toList))
-          ~> exportResourceMetrics connection
+          ~> exportResourceMetrics openTelemetryExporter
           ~> M.liftTick (mapping (D.singleton . ExportMetricsResultStat))
     , -- Export spans.
       runIf (C.shouldExportTraces fullConfig) $
@@ -299,12 +299,12 @@ exportResourceTelemetryData fullConfig connection =
           -- NOTE: See note above.
           ~> M.batchByTick
           ~> M.liftTick (mapping (toExportTracesServiceRequest . D.toList))
-          ~> exportResourceSpans connection
+          ~> exportResourceSpans openTelemetryExporter
           ~> M.liftTick (mapping (D.singleton . ExportTraceResultStat))
     , -- Export profiles.
       runIf (C.shouldExportProfiles fullConfig) $
         M.liftTick (mapping getResourceProfiles ~> asParts ~> mapping toExportProfileServiceRequest)
-          ~> exportResourceProfiles connection
+          ~> exportResourceProfiles openTelemetryExporter
           ~> M.liftTick (mapping (D.singleton . ExportProfileResultStat))
     ]
 

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Core.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Core.hs
@@ -1,0 +1,173 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module GHC.Eventlog.Live.Otelcol.Exporter.Core (
+  OpenTelemetryExporter (..),
+  HttpProtobufExporter,
+  HttpProtobufError (..),
+  validateOpenTelemetryCollectorOptions,
+  withOpenTelemetryExporter,
+  sendHttpProtobuf,
+) where
+
+import Control.Exception (Exception (..), throwIO)
+import Control.Monad (forM_)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Char8 qualified as BSC
+import Data.ByteString.Lazy qualified as BSL
+import Data.CaseInsensitive qualified as CI
+import Data.Functor (void)
+import Data.Maybe (fromMaybe)
+import Data.ProtoLens.Encoding qualified as Proto
+import Data.ProtoLens.Message (Message (defMessage))
+import GHC.Eventlog.Live.Otelcol.Options (
+  HttpHeader (..),
+  HttpProtobufOptions (..),
+  OpenTelemetryCollectorOptions (..),
+  OpenTelemetryCollectorProtocol (..),
+ )
+import Network.GRPC.Client qualified as G
+import Network.GRPC.Common qualified as G
+import Network.HTTP.Client qualified as H
+import Network.HTTP.Client.TLS qualified as H
+import Network.HTTP.Types.Header qualified as HTTP
+import Network.HTTP.Types.Status qualified as HTTP
+import Text.Printf (printf)
+
+data OpenTelemetryExporter
+  = OpenTelemetryExporter'Grpc G.Connection
+  | OpenTelemetryExporter'Http HttpProtobufExporter
+
+data HttpProtobufExporter = HttpProtobufExporter
+  { manager :: H.Manager
+  , baseUrl :: String
+  , headers :: HTTP.RequestHeaders
+  }
+
+data HttpProtobufError
+  = HttpProtobufStatusError
+      { statusCode :: Int
+      , statusMessage :: ByteString
+      , responseBody :: ByteString
+      }
+  | HttpProtobufDecodeError
+      { errorMessage :: String
+      }
+  deriving (Show)
+
+instance Exception HttpProtobufError where
+  displayException :: HttpProtobufError -> String
+  displayException = \case
+    HttpProtobufStatusError{..} ->
+      printf
+        "Error: OpenTelemetry Collector HTTP/Protobuf endpoint returned status %d %s with body: %s"
+        statusCode
+        (BSC.unpack statusMessage)
+        (BSC.unpack responseBody)
+    HttpProtobufDecodeError{..} ->
+      "Error: Could not decode OpenTelemetry Collector HTTP/Protobuf response: " <> errorMessage
+
+withOpenTelemetryExporter :: OpenTelemetryCollectorOptions -> (OpenTelemetryExporter -> IO a) -> IO a
+withOpenTelemetryExporter options action =
+  case toExporterOptions options of
+    Left err -> ioError (userError err)
+    Right (ExporterOptions'Grpc server) ->
+      G.withConnection G.def server $ \conn ->
+        action (OpenTelemetryExporter'Grpc conn)
+    Right (ExporterOptions'HttpProtobuf httpProtobufOptions) -> do
+      manager <- H.newManager H.tlsManagerSettings
+      action . OpenTelemetryExporter'Http $ makeHttpProtobufExporter manager httpProtobufOptions
+
+validateOpenTelemetryCollectorOptions :: OpenTelemetryCollectorOptions -> Either String ()
+validateOpenTelemetryCollectorOptions = void . toExporterOptions
+
+data ExporterOptions
+  = ExporterOptions'Grpc G.Server
+  | ExporterOptions'HttpProtobuf HttpProtobufOptions
+
+toExporterOptions :: OpenTelemetryCollectorOptions -> Either String ExporterOptions
+toExporterOptions OpenTelemetryCollectorOptions{..} =
+  case openTelemetryCollectorProtocol of
+    OpenTelemetryCollectorProtocol'Grpc -> do
+      case otelcolHeaders of
+        [] -> Right ()
+        _ : _ -> Left "--otelcol-header is only supported with --otelcol-protocol=http-protobuf."
+      Right . ExporterOptions'Grpc $
+        makeServer
+          (G.Address otelcolHost (maybe 4317 fromIntegral maybeOtelcolPort) maybeOtelcolAuthority)
+          otelcolSsl
+          (makeServerValidation maybeOtelcolCertificateStore)
+          (fromMaybe G.SslKeyLogNone maybeOtelcolSslKeyLog)
+    OpenTelemetryCollectorProtocol'HttpProtobuf -> do
+      forM_ maybeOtelcolAuthority $ \_ ->
+        Left "--otelcol-authority is only supported with --otelcol-protocol=grpc."
+      forM_ maybeOtelcolCertificateStore $ \_ ->
+        Left "--otelcol-certificate-store is only supported with --otelcol-protocol=grpc."
+      forM_ maybeOtelcolSslKeyLog $ \_ ->
+        Left "--otelcol-ssl-key-log and --otelcol-ssl-key-log-from-env are only supported with --otelcol-protocol=grpc."
+      pure . ExporterOptions'HttpProtobuf $
+        HttpProtobufOptions
+          { httpProtobufScheme = if otelcolSsl then "https" else "http"
+          , httpProtobufHost = otelcolHost
+          , httpProtobufPort = fromMaybe 4318 maybeOtelcolPort
+          , httpProtobufHeaders = otelcolHeaders
+          }
+ where
+  makeServer :: G.Address -> Bool -> G.ServerValidation -> G.SslKeyLog -> G.Server
+  makeServer address ssl serverValidation sslKeyLog
+    | ssl = G.ServerSecure serverValidation sslKeyLog address
+    | otherwise = G.ServerInsecure address
+
+  makeServerValidation :: Maybe FilePath -> G.ServerValidation
+  makeServerValidation =
+    G.ValidateServer . maybe G.certStoreFromSystem G.certStoreFromPath
+
+makeHttpProtobufExporter :: H.Manager -> HttpProtobufOptions -> HttpProtobufExporter
+makeHttpProtobufExporter manager HttpProtobufOptions{..} =
+  HttpProtobufExporter
+    { manager = manager
+    , baseUrl = httpProtobufScheme <> "://" <> httpProtobufHost <> ":" <> show httpProtobufPort
+    , headers =
+        map
+          ( \HttpHeader{..} ->
+              ( CI.mk (BSC.pack httpHeaderName)
+              , BSC.pack httpHeaderValue
+              )
+          )
+          httpProtobufHeaders
+    }
+
+sendHttpProtobuf :: (Message req, Message resp) => HttpProtobufExporter -> String -> req -> IO resp
+sendHttpProtobuf HttpProtobufExporter{..} path req = do
+  baseRequest <- H.parseRequest (baseUrl <> path)
+  let request =
+        baseRequest
+          { H.method = "POST"
+          , H.requestBody = H.RequestBodyBS (Proto.encodeMessage req)
+          , H.checkResponse = \_ _ -> pure ()
+          , H.requestHeaders =
+              [ (HTTP.hContentType, "application/x-protobuf")
+              , (HTTP.hAccept, "application/x-protobuf")
+              ]
+                <> headers
+          }
+  response <- H.httpLbs request manager
+  let status = H.responseStatus response
+  let body = BSL.toStrict (H.responseBody response)
+  if HTTP.statusIsSuccessful status
+    then decodeResponseBody body
+    else
+      throwIO
+        HttpProtobufStatusError
+          { statusCode = HTTP.statusCode status
+          , statusMessage = HTTP.statusMessage status
+          , responseBody = body
+          }
+
+decodeResponseBody :: (Message msg) => ByteString -> IO msg
+decodeResponseBody body
+  | BS.null body = pure defMessage
+  | otherwise =
+      case Proto.decodeMessage body of
+        Left errorMessage -> throwIO HttpProtobufDecodeError{..}
+        Right msg -> pure msg

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Core.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Core.hs
@@ -91,7 +91,7 @@ toExporterOptions OpenTelemetryCollectorOptions{..} =
     OpenTelemetryCollectorProtocol'Grpc -> do
       case otelcolHeaders of
         [] -> Right ()
-        _ : _ -> Left "--otelcol-header is only supported with --otelcol-protocol=http-protobuf."
+        _ : _ -> Left "--otelcol-header is only supported with --otelcol-protocol=http/protobuf."
       Right . ExporterOptions'Grpc $
         makeServer
           (G.Address otelcolHost (maybe 4317 fromIntegral maybeOtelcolPort) maybeOtelcolAuthority)

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Core.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Core.hs
@@ -1,12 +1,18 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module GHC.Eventlog.Live.Otelcol.Exporter.Core (
   OpenTelemetryExporter (..),
-  HttpProtobufExporter,
-  HttpProtobufError (..),
   validateOpenTelemetryCollectorOptions,
   withOpenTelemetryExporter,
-  sendHttpProtobuf,
+  export,
+
+  -- * Export via gRPC
+  CanExportViaGrpc,
+
+  -- * Export via HTTP/Protobuf
+  CanExportViaHttpProtobuf (..),
+  HttpProtobufError (..),
 ) where
 
 import Control.Exception (Exception (..), throwIO)
@@ -20,23 +26,142 @@ import Data.Functor (void)
 import Data.Maybe (fromMaybe)
 import Data.ProtoLens.Encoding qualified as Proto
 import Data.ProtoLens.Message (Message (defMessage))
-import GHC.Eventlog.Live.Otelcol.Options (
-  HttpHeader (..),
-  HttpProtobufOptions (..),
-  OpenTelemetryCollectorOptions (..),
-  OpenTelemetryCollectorProtocol (..),
- )
+import Data.ProtoLens.Service.Types (HasMethodImpl (..))
+import GHC.Eventlog.Live.Otelcol.Options (HttpHeader (..), HttpProtobufOptions (..), OpenTelemetryCollectorOptions (..), OpenTelemetryCollectorProtocol (..))
 import Network.GRPC.Client qualified as G
+import Network.GRPC.Client.StreamType.IO qualified as G
 import Network.GRPC.Common qualified as G
+import Network.GRPC.Common.Protobuf (Protobuf, StreamingType (..))
+import Network.GRPC.Common.Protobuf qualified as G
+import Network.GRPC.Common.StreamType qualified as G
 import Network.HTTP.Client qualified as H
 import Network.HTTP.Client.TLS qualified as H
 import Network.HTTP.Types.Header qualified as HTTP
 import Network.HTTP.Types.Status qualified as HTTP
 import Text.Printf (printf)
 
+--------------------------------------------------------------------------------
+-- OTLP Exporter
+--------------------------------------------------------------------------------
+
 data OpenTelemetryExporter
-  = OpenTelemetryExporter'Grpc G.Connection
-  | OpenTelemetryExporter'Http HttpProtobufExporter
+  = OpenTelemetryExporter'Grpc GrpcExporter
+  | OpenTelemetryExporter'HttpProtobuf HttpProtobufExporter
+
+{- |
+Construct an t`OpenTelemetryExporter` from t`OpenTelemetryCollectorOptions`.
+-}
+withOpenTelemetryExporter :: OpenTelemetryCollectorOptions -> (OpenTelemetryExporter -> IO a) -> IO a
+withOpenTelemetryExporter options action =
+  case toExporterOptions options of
+    Left err ->
+      ioError (userError err)
+    Right (ExporterOptions'Grpc server) ->
+      G.withConnection G.def server $ \conn ->
+        action (OpenTelemetryExporter'Grpc (GrpcExporter conn))
+    Right (ExporterOptions'HttpProtobuf httpProtobufOptions) -> do
+      manager <- H.newManager H.tlsManagerSettings
+      action (OpenTelemetryExporter'HttpProtobuf $ makeHttpProtobufExporter manager httpProtobufOptions)
+
+{- |
+Internal helper.
+
+This is the result of successfully interpreting t`OpenTelemetryCollectorOptions` as either gRPC or HTTP/Protobuf options.
+-}
+data ExporterOptions
+  = ExporterOptions'Grpc G.Server
+  | ExporterOptions'HttpProtobuf HttpProtobufOptions
+
+{- |
+Check that the t`OpenTelemetryCollectorOptions` options are consistent.
+-}
+validateOpenTelemetryCollectorOptions :: OpenTelemetryCollectorOptions -> Either String ()
+validateOpenTelemetryCollectorOptions = void . toExporterOptions
+
+{- |
+Internal helper.
+
+Interpret t`OpenTelemetryCollectorOptions` as either gRPC or HTTP/Protobuf options.
+-}
+toExporterOptions :: OpenTelemetryCollectorOptions -> Either String ExporterOptions
+toExporterOptions OpenTelemetryCollectorOptions{..} =
+  case openTelemetryCollectorProtocol of
+    OpenTelemetryCollectorProtocol'Grpc -> do
+      case otelcolHeaders of
+        [] -> Right ()
+        _ : _ -> Left "--otelcol-header is only supported with --otelcol-protocol=http/protobuf."
+      Right . ExporterOptions'Grpc $
+        makeGrpcServer
+          (G.Address otelcolHost (maybe 4317 fromIntegral maybeOtelcolPort) maybeOtelcolAuthority)
+          otelcolSsl
+          (makeGrpcServerValidation maybeOtelcolCertificateStore)
+          (fromMaybe G.SslKeyLogNone maybeOtelcolSslKeyLog)
+    OpenTelemetryCollectorProtocol'HttpProtobuf -> do
+      forM_ maybeOtelcolAuthority $ \_ ->
+        Left "--otelcol-authority is only supported with --otelcol-protocol=grpc."
+      forM_ maybeOtelcolCertificateStore $ \_ ->
+        Left "--otelcol-certificate-store is only supported with --otelcol-protocol=grpc."
+      forM_ maybeOtelcolSslKeyLog $ \_ ->
+        Left "--otelcol-ssl-key-log and --otelcol-ssl-key-log-from-env are only supported with --otelcol-protocol=grpc."
+      pure . ExporterOptions'HttpProtobuf $
+        HttpProtobufOptions
+          { httpProtobufScheme = if otelcolSsl then "https" else "http"
+          , httpProtobufHost = otelcolHost
+          , httpProtobufPort = fromMaybe 4318 maybeOtelcolPort
+          , httpProtobufHeaders = otelcolHeaders
+          }
+ where
+  makeGrpcServer :: G.Address -> Bool -> G.ServerValidation -> G.SslKeyLog -> G.Server
+  makeGrpcServer address ssl serverValidation sslKeyLog
+    | ssl = G.ServerSecure serverValidation sslKeyLog address
+    | otherwise = G.ServerInsecure address
+
+  makeGrpcServerValidation :: Maybe FilePath -> G.ServerValidation
+  makeGrpcServerValidation =
+    G.ValidateServer . maybe G.certStoreFromSystem G.certStoreFromPath
+
+export ::
+  forall serv meth.
+  ( CanExportViaGrpc serv meth
+  , CanExportViaHttpProtobuf serv meth
+  ) =>
+  -- | The HTTP/Protobuf exporter.
+  OpenTelemetryExporter ->
+  -- | The request message.
+  MethodInput serv meth ->
+  IO (MethodOutput serv meth)
+export = \case
+  OpenTelemetryExporter'Grpc grpcExporter ->
+    sendGrpc @serv @meth grpcExporter
+  OpenTelemetryExporter'HttpProtobuf httpProtobufExporter ->
+    sendHttpProtobuf @serv @meth httpProtobufExporter
+
+--------------------------------------------------------------------------------
+-- OTLP gRPC Exporter
+--------------------------------------------------------------------------------
+
+newtype GrpcExporter = GrpcExporter
+  { connection :: G.Connection
+  }
+
+type CanExportViaGrpc serv meth =
+  ( G.SupportsClientRpc (Protobuf serv meth)
+  , G.SupportsStreamingType (Protobuf serv meth) 'NonStreaming
+  , G.RequestMetadata (Protobuf serv meth) ~ G.NoMetadata
+  )
+
+sendGrpc ::
+  forall serv meth.
+  (CanExportViaGrpc serv meth) =>
+  GrpcExporter ->
+  MethodInput serv meth ->
+  IO (MethodOutput serv meth)
+sendGrpc grpcExporter input =
+  G.getProto <$> G.nonStreaming grpcExporter.connection (G.rpc @(G.Protobuf serv meth)) (G.Proto input)
+
+--------------------------------------------------------------------------------
+-- OTLP HTTP/Protobuf Exporter
+--------------------------------------------------------------------------------
 
 data HttpProtobufExporter = HttpProtobufExporter
   { manager :: H.Manager
@@ -67,79 +192,49 @@ instance Exception HttpProtobufError where
     HttpProtobufDecodeError{..} ->
       "Error: Could not decode OpenTelemetry Collector HTTP/Protobuf response: " <> errorMessage
 
-withOpenTelemetryExporter :: OpenTelemetryCollectorOptions -> (OpenTelemetryExporter -> IO a) -> IO a
-withOpenTelemetryExporter options action =
-  case toExporterOptions options of
-    Left err -> ioError (userError err)
-    Right (ExporterOptions'Grpc server) ->
-      G.withConnection G.def server $ \conn ->
-        action (OpenTelemetryExporter'Grpc conn)
-    Right (ExporterOptions'HttpProtobuf httpProtobufOptions) -> do
-      manager <- H.newManager H.tlsManagerSettings
-      action . OpenTelemetryExporter'Http $ makeHttpProtobufExporter manager httpProtobufOptions
-
-validateOpenTelemetryCollectorOptions :: OpenTelemetryCollectorOptions -> Either String ()
-validateOpenTelemetryCollectorOptions = void . toExporterOptions
-
-data ExporterOptions
-  = ExporterOptions'Grpc G.Server
-  | ExporterOptions'HttpProtobuf HttpProtobufOptions
-
-toExporterOptions :: OpenTelemetryCollectorOptions -> Either String ExporterOptions
-toExporterOptions OpenTelemetryCollectorOptions{..} =
-  case openTelemetryCollectorProtocol of
-    OpenTelemetryCollectorProtocol'Grpc -> do
-      case otelcolHeaders of
-        [] -> Right ()
-        _ : _ -> Left "--otelcol-header is only supported with --otelcol-protocol=http/protobuf."
-      Right . ExporterOptions'Grpc $
-        makeServer
-          (G.Address otelcolHost (maybe 4317 fromIntegral maybeOtelcolPort) maybeOtelcolAuthority)
-          otelcolSsl
-          (makeServerValidation maybeOtelcolCertificateStore)
-          (fromMaybe G.SslKeyLogNone maybeOtelcolSslKeyLog)
-    OpenTelemetryCollectorProtocol'HttpProtobuf -> do
-      forM_ maybeOtelcolAuthority $ \_ ->
-        Left "--otelcol-authority is only supported with --otelcol-protocol=grpc."
-      forM_ maybeOtelcolCertificateStore $ \_ ->
-        Left "--otelcol-certificate-store is only supported with --otelcol-protocol=grpc."
-      forM_ maybeOtelcolSslKeyLog $ \_ ->
-        Left "--otelcol-ssl-key-log and --otelcol-ssl-key-log-from-env are only supported with --otelcol-protocol=grpc."
-      pure . ExporterOptions'HttpProtobuf $
-        HttpProtobufOptions
-          { httpProtobufScheme = if otelcolSsl then "https" else "http"
-          , httpProtobufHost = otelcolHost
-          , httpProtobufPort = fromMaybe 4318 maybeOtelcolPort
-          , httpProtobufHeaders = otelcolHeaders
-          }
- where
-  makeServer :: G.Address -> Bool -> G.ServerValidation -> G.SslKeyLog -> G.Server
-  makeServer address ssl serverValidation sslKeyLog
-    | ssl = G.ServerSecure serverValidation sslKeyLog address
-    | otherwise = G.ServerInsecure address
-
-  makeServerValidation :: Maybe FilePath -> G.ServerValidation
-  makeServerValidation =
-    G.ValidateServer . maybe G.certStoreFromSystem G.certStoreFromPath
-
+{- |
+Internal helper.
+-}
 makeHttpProtobufExporter :: H.Manager -> HttpProtobufOptions -> HttpProtobufExporter
 makeHttpProtobufExporter manager HttpProtobufOptions{..} =
   HttpProtobufExporter
     { manager = manager
     , baseUrl = httpProtobufScheme <> "://" <> httpProtobufHost <> ":" <> show httpProtobufPort
-    , headers =
-        map
-          ( \HttpHeader{..} ->
-              ( CI.mk (BSC.pack httpHeaderName)
-              , BSC.pack httpHeaderValue
-              )
-          )
-          httpProtobufHeaders
+    , headers = makeRequestHeaders httpProtobufHeaders
     }
 
-sendHttpProtobuf :: (Message req, Message resp) => HttpProtobufExporter -> String -> req -> IO resp
-sendHttpProtobuf HttpProtobufExporter{..} path req = do
-  baseRequest <- H.parseRequest (baseUrl <> path)
+{- |
+Internal helper.
+
+Convert a list of t`HttpHeader` headers to `HTTP.RequestHeaders`.
+-}
+makeRequestHeaders :: [HttpHeader] -> HTTP.RequestHeaders
+makeRequestHeaders httpHeaders =
+  [ (CI.mk (BSC.pack httpHeaderName), BSC.pack httpHeaderValue)
+  | HttpHeader{..} <- httpHeaders
+  ]
+
+class
+  ( Message (MethodInput serv meth)
+  , Message (MethodOutput serv meth)
+  ) =>
+  CanExportViaHttpProtobuf serv meth
+  where
+  apiPath :: String
+
+{- |
+Send a Protobuf message over an HTTP connection.
+-}
+sendHttpProtobuf ::
+  forall serv meth.
+  (CanExportViaHttpProtobuf serv meth) =>
+  -- | The HTTP/Protobuf exporter.
+  HttpProtobufExporter ->
+  -- | The request message.
+  MethodInput serv meth ->
+  IO (MethodOutput serv meth)
+sendHttpProtobuf HttpProtobufExporter{..} req = do
+  baseRequest <- H.parseRequest (baseUrl <> apiPath @serv @meth)
   let request =
         baseRequest
           { H.method = "POST"
@@ -164,6 +259,11 @@ sendHttpProtobuf HttpProtobufExporter{..} path req = do
           , responseBody = body
           }
 
+{- |
+Internal helper.
+
+Decode the HTTP response body into a Protobuf message.
+-}
 decodeResponseBody :: (Message msg) => ByteString -> IO msg
 decodeResponseBody body
   | BS.null body = pure defMessage

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Core.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Core.hs
@@ -16,6 +16,7 @@ module GHC.Eventlog.Live.Otelcol.Exporter.Core (
 ) where
 
 import Control.Exception (Exception (..), throwIO)
+import Control.Monad ((<=<))
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Char8 qualified as BSC
@@ -105,7 +106,7 @@ parseOtlpEndpoint = go True
             , null uriQuery
             , null uriFragment -> do
                 let !host = maybe "localhost" (.uriRegName) uriAuthority
-                let !port = fromMaybe 4317 (readMaybe @Word16 . drop 1 . (.uriPort) =<< uriAuthority)
+                let !port = fromMaybe 4317 $ uriPortNumber uriAuthority
                 let !secure = uriScheme == "https:"
                 pure $ Left OtlpGrpcEndpoint{..}
             | otherwise ->
@@ -115,15 +116,10 @@ parseOtlpEndpoint = go True
             , null uriQuery
             , null uriFragment -> do
                 let !host = maybe "localhost" (.uriRegName) uriAuthority
-                let !port = fromMaybe 4317 (readMaybe @Word16 . drop 1 . (.uriPort) =<< uriAuthority)
-                let !baseUrl =
-                      show
-                        URI.nullURI
-                          { URI.uriScheme = uriScheme
-                          , URI.uriAuthority = Just URI.URIAuth{uriUserInfo = "", uriRegName = host, uriPort = show port}
-                          , URI.uriPath = uriPath
-                          }
-                pure $ Right OtlpHttpEndpoint{..}
+                let !port = fromMaybe 4317 $ uriPortNumber uriAuthority
+                let !auth = URI.nullURIAuth{URI.uriRegName = host, URI.uriPort = ':' : show port}
+                let !baseURI = URI.nullURI{URI.uriScheme = uriScheme, URI.uriAuthority = Just auth, URI.uriPath = uriPath}
+                pure $ Right OtlpHttpEndpoint{baseUrl = show baseURI}
             | otherwise ->
                 Left $ "The HTTP/Protobuf protocol only supports HTTP and HTTPS and does not support an URI query or fragment, found: " <> url
       Nothing
@@ -132,6 +128,20 @@ parseOtlpEndpoint = go True
         | otherwise ->
             Left $ "Could not parse url " <> url
 
+{- |
+Internal helper.
+
+Extract a t`Word16` port number from a `URI.URIAuth`.
+-}
+uriPortNumber :: Maybe URI.URIAuth -> Maybe Word16
+uriPortNumber = readMaybe @Word16 <=< fmap (dropColon . (.uriPort))
+ where
+  dropColon :: String -> String
+  dropColon = \case (':' : str) -> str; str -> str
+
+{- |
+Export telemetry data to the t`OtlpExporter`.
+-}
 export ::
   forall serv meth.
   ( CanExportViaGrpc serv meth

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Core.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Core.hs
@@ -26,6 +26,7 @@ import Data.Maybe (fromMaybe)
 import Data.ProtoLens.Encoding qualified as Proto
 import Data.ProtoLens.Message (Message (defMessage))
 import Data.ProtoLens.Service.Types (HasMethodImpl (..))
+import Data.Word (Word16)
 import GHC.Eventlog.Live.Otelcol.Options (OtlpExporterOptions (..), OtlpProtocol (..))
 import Network.GRPC.Client qualified as G
 import Network.GRPC.Client.StreamType.IO qualified as G
@@ -37,8 +38,8 @@ import Network.HTTP.Client qualified as H
 import Network.HTTP.Client.TLS qualified as H
 import Network.HTTP.Types.Header qualified as HTTP
 import Network.HTTP.Types.Status qualified as HTTP
-import Network.URL (URL (url_path))
-import Network.URL qualified as URL
+import Network.URI qualified as URI
+import Text.Read (readMaybe)
 
 --------------------------------------------------------------------------------
 -- OTLP Exporter
@@ -54,17 +55,17 @@ Construct an t`OtlpExporter` from t`OtlpExporterOptions`.
 withOtlpExporter :: OtlpExporterOptions OtlpEndpoint -> (OtlpExporter -> IO a) -> IO a
 withOtlpExporter options action =
   case options of
-    OtlpExporterOptions{otlpEndpoint = Left otlpEndpointGrpc, ..} -> do
-      let options' = OtlpExporterOptions{otlpEndpoint = otlpEndpointGrpc, ..}
+    OtlpExporterOptions{otlpEndpoint = Left otlpGrpcEndpoint, ..} -> do
+      let options' = OtlpExporterOptions{otlpEndpoint = otlpGrpcEndpoint, ..}
       withOtlpGrpcExporter options' $ action . OtlpExporterGrpc
-    OtlpExporterOptions{otlpEndpoint = Right otlpEndpointHttp, ..} -> do
-      let options' = OtlpExporterOptions{otlpEndpoint = otlpEndpointHttp, ..}
+    OtlpExporterOptions{otlpEndpoint = Right otlpHttpEndpoint, ..} -> do
+      let options' = OtlpExporterOptions{otlpEndpoint = otlpHttpEndpoint, ..}
       withOtlpHttpProtobufExporter options' $ action . OtlpExporterHttpProtobuf
 
 {- |
 The options for an OTLP endpoint.
 -}
-type OtlpEndpoint = Either OtlpEndpointGrpc OtlpEndpointHttp
+type OtlpEndpoint = Either OtlpGrpcEndpoint OtlpHttpEndpoint
 
 {- |
 Parse the OTLP endpoint from a t`String` to an t`OtlpEndpoint`.
@@ -95,50 +96,41 @@ parseOtlpEndpoint = go True
  where
   go :: Bool -> OtlpProtocol -> String -> Either String OtlpEndpoint
   go retry otlpProtocol url =
-    case URL.importURL url of
-      Just URL.URL{url_type = URL.Absolute URL.Host{..}, ..} ->
+    case URI.parseURI url of
+      Just URI.URI{..} ->
         case otlpProtocol of
           OtlpProtocolGrpc
-            | not (null url_path) ->
-                Left $ "The grpc protocol does not support an URL path, found: " <> URL.encString False URL.ok_path url_path
-            | not (null url_params) ->
-                Left $ "The grpc protocol does not support URL parameters, found: " <> URL.exportParams url_params
-            | URL.HTTP secure <- protocol ->
-                Right . Left $
-                  OtlpEndpointGrpc
-                    { otlpGrpcHost = host
-                    , otlpGrpcPort = fromMaybe 4317 port
-                    , otlpGrpcSecure = secure
-                    }
+            | uriScheme `elem` ["http:", "https:"]
+            , null uriPath
+            , null uriQuery
+            , null uriFragment -> do
+                let !host = maybe "localhost" (.uriRegName) uriAuthority
+                let !port = fromMaybe 4317 (readMaybe @Word16 . drop 1 . (.uriPort) =<< uriAuthority)
+                let !secure = uriScheme == "https:"
+                pure $ Left OtlpGrpcEndpoint{..}
             | otherwise ->
-                Left $ "The grpc protocol does not support " <> exportProt protocol
+                Left $ "The gRPC protocol only supports HTTP and HTTPS and does not support an URI path, query, or fragment, found: " <> url
           OtlpProtocolHttpProtobuf
-            | URL.HTTP secure <- protocol ->
-                Right . Right $
-                  OtlpEndpointHttp
-                    { otlpHttpHost = host
-                    , otlpHttpPort = fromMaybe 4318 port
-                    , otlpHttpSecure = secure
-                    , otlpHttpPath = url_path
-                    , otlpHttpParams = url_params
-                    }
+            | uriScheme `elem` ["http:", "https:"]
+            , null uriQuery
+            , null uriFragment -> do
+                let !host = maybe "localhost" (.uriRegName) uriAuthority
+                let !port = fromMaybe 4317 (readMaybe @Word16 . drop 1 . (.uriPort) =<< uriAuthority)
+                let !baseUrl =
+                      show
+                        URI.nullURI
+                          { URI.uriScheme = uriScheme
+                          , URI.uriAuthority = Just URI.URIAuth{uriUserInfo = "", uriRegName = host, uriPort = show port}
+                          , URI.uriPath = uriPath
+                          }
+                pure $ Right OtlpHttpEndpoint{..}
             | otherwise ->
-                Left $ "The http/protobuf protocol does not support " <> exportProt protocol
-      Just URL.URL{url_type = URL.PathRelative{}}
+                Left $ "The HTTP/Protobuf protocol only supports HTTP and HTTPS and does not support an URI query or fragment, found: " <> url
+      Nothing
         | retry ->
-            go False otlpProtocol ("http://" <> url)
-      Just URL.URL{} ->
-        Left $ "Endpoint must be absolute URL, found " <> url
-      Nothing ->
-        Left $ "Could not parse url " <> url
-
-  exportProt :: URL.Protocol -> String
-  exportProt prot = case prot of
-    URL.HTTP True -> "https"
-    URL.HTTP False -> "http"
-    URL.FTP True -> "ftps"
-    URL.FTP False -> "ftp"
-    URL.RawProt s -> s
+            go False otlpProtocol $ "http://" <> url
+        | otherwise ->
+            Left $ "Could not parse url " <> url
 
 export ::
   forall serv meth.
@@ -168,10 +160,10 @@ newtype OtlpGrpcExporter = OtlpGrpcExporter
 {- |
 The options for an OTLP gRPC endpoint.
 -}
-data OtlpEndpointGrpc = OtlpEndpointGrpc
-  { otlpGrpcHost :: !String
-  , otlpGrpcPort :: !Integer
-  , otlpGrpcSecure :: !Bool
+data OtlpGrpcEndpoint = OtlpGrpcEndpoint
+  { host :: !String
+  , port :: !Word16
+  , secure :: !Bool
   }
 
 type CanExportViaGrpc serv meth =
@@ -180,16 +172,16 @@ type CanExportViaGrpc serv meth =
   , G.RequestMetadata (Protobuf serv meth) ~ G.NoMetadata
   )
 
-withOtlpGrpcExporter :: OtlpExporterOptions OtlpEndpointGrpc -> (OtlpGrpcExporter -> IO a) -> IO a
-withOtlpGrpcExporter OtlpExporterOptions{otlpEndpoint = OtlpEndpointGrpc{..}, ..} action =
+withOtlpGrpcExporter :: OtlpExporterOptions OtlpGrpcEndpoint -> (OtlpGrpcExporter -> IO a) -> IO a
+withOtlpGrpcExporter OtlpExporterOptions{otlpEndpoint = OtlpGrpcEndpoint{..}, ..} action =
   G.withConnection G.def server $ \connection -> action OtlpGrpcExporter{..}
  where
   server :: G.Server
   server
-    | otlpGrpcSecure = G.ServerSecure serverValidation sslKeyLog address
+    | secure = G.ServerSecure serverValidation sslKeyLog address
     | otherwise = G.ServerInsecure address
 
-  address = G.Address otlpGrpcHost (fromIntegral otlpGrpcPort) Nothing
+  address = G.Address host (fromIntegral port) Nothing
   sslKeyLog = fromMaybe G.SslKeyLogNone otlpGrpcSslKeyLog
   serverValidation = G.ValidateServer $ maybe G.certStoreFromSystem G.certStoreFromPath otlpGrpcCertificateStore
 
@@ -209,12 +201,8 @@ exportGrpc grpcExporter input =
 {- |
 The options for an OTLP HTTP/Protobuf endpoint.
 -}
-data OtlpEndpointHttp = OtlpEndpointHttp
-  { otlpHttpHost :: !String
-  , otlpHttpPort :: !Integer
-  , otlpHttpSecure :: !Bool
-  , otlpHttpPath :: !String
-  , otlpHttpParams :: ![(String, String)]
+newtype OtlpHttpEndpoint = OtlpHttpEndpoint
+  { baseUrl :: String
   }
   deriving (Show)
 
@@ -254,19 +242,14 @@ Internal helper.
 
 Run an action with an t`OtlpHttpProtobufExporter`.
 -}
-withOtlpHttpProtobufExporter :: OtlpExporterOptions OtlpEndpointHttp -> (OtlpHttpProtobufExporter -> IO a) -> IO a
-withOtlpHttpProtobufExporter OtlpExporterOptions{otlpEndpoint = OtlpEndpointHttp{..}, ..} action = do
+withOtlpHttpProtobufExporter :: OtlpExporterOptions OtlpHttpEndpoint -> (OtlpHttpProtobufExporter -> IO a) -> IO a
+withOtlpHttpProtobufExporter OtlpExporterOptions{otlpEndpoint = OtlpHttpEndpoint{..}, ..} action = do
   -- Create an HTTP manager.
   manager <- H.newManager H.tlsManagerSettings
-  -- Create the HTTP baseUrl.
-  let baseUrlType = URL.Absolute URL.Host{protocol = URL.HTTP otlpHttpSecure, host = otlpHttpHost, port = Just otlpHttpPort}
-  let baseUrl = URL.URL{url_type = baseUrlType, url_path = otlpHttpPath, url_params = otlpHttpParams}
   -- Create the HTTP headers.
   let headers = [(CI.mk (BSC.pack name), BSC.pack value) | (name, value) <- fromMaybe [] otlpHttpHeaders]
-  -- Create the HTTP/Protobuf exporter.
-  let exporter = OtlpHttpProtobufExporter{manager = manager, baseUrl = URL.exportURL baseUrl, headers = headers}
   -- Run the action.
-  action exporter
+  action OtlpHttpProtobufExporter{..}
 
 class
   ( Message (MethodInput serv meth)

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Core.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Core.hs
@@ -2,9 +2,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module GHC.Eventlog.Live.Otelcol.Exporter.Core (
-  OpenTelemetryExporter (..),
-  validateOpenTelemetryCollectorOptions,
-  withOpenTelemetryExporter,
+  OtlpExporter (..),
+  parseOtlpExporterOptions,
+  withOtlpExporter,
   export,
 
   -- * Export via gRPC
@@ -12,22 +12,21 @@ module GHC.Eventlog.Live.Otelcol.Exporter.Core (
 
   -- * Export via HTTP/Protobuf
   CanExportViaHttpProtobuf (..),
-  HttpProtobufError (..),
+  HttpError (..),
 ) where
 
 import Control.Exception (Exception (..), throwIO)
-import Control.Monad (forM_)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Char8 qualified as BSC
 import Data.ByteString.Lazy qualified as BSL
 import Data.CaseInsensitive qualified as CI
-import Data.Functor (void)
+import Data.List qualified as L
 import Data.Maybe (fromMaybe)
 import Data.ProtoLens.Encoding qualified as Proto
 import Data.ProtoLens.Message (Message (defMessage))
 import Data.ProtoLens.Service.Types (HasMethodImpl (..))
-import GHC.Eventlog.Live.Otelcol.Options (HttpHeader (..), HttpProtobufOptions (..), OpenTelemetryCollectorOptions (..), OpenTelemetryCollectorProtocol (..))
+import GHC.Eventlog.Live.Otelcol.Options (OtlpExporterOptions (..), OtlpProtocol (..))
 import Network.GRPC.Client qualified as G
 import Network.GRPC.Client.StreamType.IO qualified as G
 import Network.GRPC.Common qualified as G
@@ -38,87 +37,108 @@ import Network.HTTP.Client qualified as H
 import Network.HTTP.Client.TLS qualified as H
 import Network.HTTP.Types.Header qualified as HTTP
 import Network.HTTP.Types.Status qualified as HTTP
-import Text.Printf (printf)
+import Network.URL (URL (url_path))
+import Network.URL qualified as URL
 
 --------------------------------------------------------------------------------
 -- OTLP Exporter
 --------------------------------------------------------------------------------
 
-data OpenTelemetryExporter
-  = OpenTelemetryExporter'Grpc GrpcExporter
-  | OpenTelemetryExporter'HttpProtobuf HttpProtobufExporter
+data OtlpExporter
+  = OtlpExporterGrpc !OtlpGrpcExporter
+  | OtlpExporterHttpProtobuf !OtlpHttpProtobufExporter
 
 {- |
-Construct an t`OpenTelemetryExporter` from t`OpenTelemetryCollectorOptions`.
+Construct an t`OtlpExporter` from t`OtlpExporterOptions`.
 -}
-withOpenTelemetryExporter :: OpenTelemetryCollectorOptions -> (OpenTelemetryExporter -> IO a) -> IO a
-withOpenTelemetryExporter options action =
-  case toExporterOptions options of
-    Left err ->
-      ioError (userError err)
-    Right (ExporterOptions'Grpc server) ->
-      G.withConnection G.def server $ \conn ->
-        action (OpenTelemetryExporter'Grpc (GrpcExporter conn))
-    Right (ExporterOptions'HttpProtobuf httpProtobufOptions) -> do
-      manager <- H.newManager H.tlsManagerSettings
-      action (OpenTelemetryExporter'HttpProtobuf $ makeHttpProtobufExporter manager httpProtobufOptions)
+withOtlpExporter :: OtlpExporterOptions OtlpEndpoint -> (OtlpExporter -> IO a) -> IO a
+withOtlpExporter options action =
+  case options of
+    OtlpExporterOptions{otlpEndpoint = Left otlpEndpointGrpc, ..} -> do
+      let options' = OtlpExporterOptions{otlpEndpoint = otlpEndpointGrpc, ..}
+      withOtlpGrpcExporter options' $ action . OtlpExporterGrpc
+    OtlpExporterOptions{otlpEndpoint = Right otlpEndpointHttp, ..} -> do
+      let options' = OtlpExporterOptions{otlpEndpoint = otlpEndpointHttp, ..}
+      withOtlpHttpProtobufExporter options' $ action . OtlpExporterHttpProtobuf
 
 {- |
-Internal helper.
-
-This is the result of successfully interpreting t`OpenTelemetryCollectorOptions` as either gRPC or HTTP/Protobuf options.
+The options for an OTLP endpoint.
 -}
-data ExporterOptions
-  = ExporterOptions'Grpc G.Server
-  | ExporterOptions'HttpProtobuf HttpProtobufOptions
+type OtlpEndpoint = Either OtlpEndpointGrpc OtlpEndpointHttp
 
 {- |
-Check that the t`OpenTelemetryCollectorOptions` options are consistent.
+Parse the OTLP endpoint from a t`String` to an t`OtlpEndpoint`.
 -}
-validateOpenTelemetryCollectorOptions :: OpenTelemetryCollectorOptions -> Either String ()
-validateOpenTelemetryCollectorOptions = void . toExporterOptions
+parseOtlpExporterOptions :: OtlpExporterOptions String -> Either String (OtlpExporterOptions OtlpEndpoint)
+parseOtlpExporterOptions OtlpExporterOptions{..} = do
+  otlpEndpoint' <- parseOtlpEndpoint otlpProtocol otlpEndpoint
+  let !options' = OtlpExporterOptions{otlpEndpoint = otlpEndpoint', ..}
+  case otlpProtocol of
+    OtlpProtocolGrpc
+      | Just headers <- otlpHttpHeaders
+      , not (null headers) -> do
+          let showHeaders = L.intercalate "," . map (\(name, value) -> name <> "=" <> value)
+          Left $ "The grpc protocol does not support additional HTTP headers, found " <> showHeaders headers
+    OtlpProtocolHttpProtobuf
+      | Just _sslKeyLog <- otlpGrpcSslKeyLog ->
+          Left $ "The http/protobuf protocol does not support the SSL key log."
+    OtlpProtocolHttpProtobuf
+      | Just certificateStore <- otlpGrpcCertificateStore ->
+          Left $ "The http/protobuf protocol does not support the certificate store, found " <> certificateStore
+    _otherwise -> pure options'
 
 {- |
-Internal helper.
-
-Interpret t`OpenTelemetryCollectorOptions` as either gRPC or HTTP/Protobuf options.
+Parse an OTLP endpoint string as an t`OtlpEndpoint` depending on the t`OtlpProtocol`.
 -}
-toExporterOptions :: OpenTelemetryCollectorOptions -> Either String ExporterOptions
-toExporterOptions OpenTelemetryCollectorOptions{..} =
-  case openTelemetryCollectorProtocol of
-    OpenTelemetryCollectorProtocol'Grpc -> do
-      case otelcolHeaders of
-        [] -> Right ()
-        _ : _ -> Left "--otelcol-header is only supported with --otelcol-protocol=http/protobuf."
-      Right . ExporterOptions'Grpc $
-        makeGrpcServer
-          (G.Address otelcolHost (maybe 4317 fromIntegral maybeOtelcolPort) maybeOtelcolAuthority)
-          otelcolSsl
-          (makeGrpcServerValidation maybeOtelcolCertificateStore)
-          (fromMaybe G.SslKeyLogNone maybeOtelcolSslKeyLog)
-    OpenTelemetryCollectorProtocol'HttpProtobuf -> do
-      forM_ maybeOtelcolAuthority $ \_ ->
-        Left "--otelcol-authority is only supported with --otelcol-protocol=grpc."
-      forM_ maybeOtelcolCertificateStore $ \_ ->
-        Left "--otelcol-certificate-store is only supported with --otelcol-protocol=grpc."
-      forM_ maybeOtelcolSslKeyLog $ \_ ->
-        Left "--otelcol-ssl-key-log and --otelcol-ssl-key-log-from-env are only supported with --otelcol-protocol=grpc."
-      pure . ExporterOptions'HttpProtobuf $
-        HttpProtobufOptions
-          { httpProtobufScheme = if otelcolSsl then "https" else "http"
-          , httpProtobufHost = otelcolHost
-          , httpProtobufPort = fromMaybe 4318 maybeOtelcolPort
-          , httpProtobufHeaders = otelcolHeaders
-          }
+parseOtlpEndpoint :: OtlpProtocol -> String -> Either String OtlpEndpoint
+parseOtlpEndpoint = go True
  where
-  makeGrpcServer :: G.Address -> Bool -> G.ServerValidation -> G.SslKeyLog -> G.Server
-  makeGrpcServer address ssl serverValidation sslKeyLog
-    | ssl = G.ServerSecure serverValidation sslKeyLog address
-    | otherwise = G.ServerInsecure address
+  go :: Bool -> OtlpProtocol -> String -> Either String OtlpEndpoint
+  go retry otlpProtocol url =
+    case URL.importURL url of
+      Just URL.URL{url_type = URL.Absolute URL.Host{..}, ..} ->
+        case otlpProtocol of
+          OtlpProtocolGrpc
+            | not (null url_path) ->
+                Left $ "The grpc protocol does not support an URL path, found: " <> URL.encString False URL.ok_path url_path
+            | not (null url_params) ->
+                Left $ "The grpc protocol does not support URL parameters, found: " <> URL.exportParams url_params
+            | URL.HTTP secure <- protocol ->
+                Right . Left $
+                  OtlpEndpointGrpc
+                    { otlpGrpcHost = host
+                    , otlpGrpcPort = fromMaybe 4317 port
+                    , otlpGrpcSecure = secure
+                    }
+            | otherwise ->
+                Left $ "The grpc protocol does not support " <> exportProt protocol
+          OtlpProtocolHttpProtobuf
+            | URL.HTTP secure <- protocol ->
+                Right . Right $
+                  OtlpEndpointHttp
+                    { otlpHttpHost = host
+                    , otlpHttpPort = fromMaybe 4318 port
+                    , otlpHttpSecure = secure
+                    , otlpHttpPath = url_path
+                    , otlpHttpParams = url_params
+                    }
+            | otherwise ->
+                Left $ "The http/protobuf protocol does not support " <> exportProt protocol
+      Just URL.URL{url_type = URL.PathRelative{}}
+        | retry ->
+            go False otlpProtocol ("http://" <> url)
+      Just URL.URL{} ->
+        Left $ "Endpoint must be absolute URL, found " <> url
+      Nothing ->
+        Left $ "Could not parse url " <> url
 
-  makeGrpcServerValidation :: Maybe FilePath -> G.ServerValidation
-  makeGrpcServerValidation =
-    G.ValidateServer . maybe G.certStoreFromSystem G.certStoreFromPath
+  exportProt :: URL.Protocol -> String
+  exportProt prot = case prot of
+    URL.HTTP True -> "https"
+    URL.HTTP False -> "http"
+    URL.FTP True -> "ftps"
+    URL.FTP False -> "ftp"
+    URL.RawProt s -> s
 
 export ::
   forall serv meth.
@@ -126,22 +146,32 @@ export ::
   , CanExportViaHttpProtobuf serv meth
   ) =>
   -- | The HTTP/Protobuf exporter.
-  OpenTelemetryExporter ->
+  OtlpExporter ->
   -- | The request message.
   MethodInput serv meth ->
   IO (MethodOutput serv meth)
 export = \case
-  OpenTelemetryExporter'Grpc grpcExporter ->
-    sendGrpc @serv @meth grpcExporter
-  OpenTelemetryExporter'HttpProtobuf httpProtobufExporter ->
-    sendHttpProtobuf @serv @meth httpProtobufExporter
+  OtlpExporterGrpc exporter -> exportGrpc @serv @meth exporter
+  OtlpExporterHttpProtobuf exporter -> exportHttpProtobuf @serv @meth exporter
 
 --------------------------------------------------------------------------------
 -- OTLP gRPC Exporter
 --------------------------------------------------------------------------------
 
-newtype GrpcExporter = GrpcExporter
+{- |
+An opaque OTLP gRPC exporter.
+-}
+newtype OtlpGrpcExporter = OtlpGrpcExporter
   { connection :: G.Connection
+  }
+
+{- |
+The options for an OTLP gRPC endpoint.
+-}
+data OtlpEndpointGrpc = OtlpEndpointGrpc
+  { otlpGrpcHost :: !String
+  , otlpGrpcPort :: !Integer
+  , otlpGrpcSecure :: !Bool
   }
 
 type CanExportViaGrpc serv meth =
@@ -150,69 +180,93 @@ type CanExportViaGrpc serv meth =
   , G.RequestMetadata (Protobuf serv meth) ~ G.NoMetadata
   )
 
-sendGrpc ::
+withOtlpGrpcExporter :: OtlpExporterOptions OtlpEndpointGrpc -> (OtlpGrpcExporter -> IO a) -> IO a
+withOtlpGrpcExporter OtlpExporterOptions{otlpEndpoint = OtlpEndpointGrpc{..}, ..} action =
+  G.withConnection G.def server $ \connection -> action OtlpGrpcExporter{..}
+ where
+  server :: G.Server
+  server
+    | otlpGrpcSecure = G.ServerSecure serverValidation sslKeyLog address
+    | otherwise = G.ServerInsecure address
+
+  address = G.Address otlpGrpcHost (fromIntegral otlpGrpcPort) Nothing
+  sslKeyLog = fromMaybe G.SslKeyLogNone otlpGrpcSslKeyLog
+  serverValidation = G.ValidateServer $ maybe G.certStoreFromSystem G.certStoreFromPath otlpGrpcCertificateStore
+
+exportGrpc ::
   forall serv meth.
   (CanExportViaGrpc serv meth) =>
-  GrpcExporter ->
+  OtlpGrpcExporter ->
   MethodInput serv meth ->
   IO (MethodOutput serv meth)
-sendGrpc grpcExporter input =
+exportGrpc grpcExporter input =
   G.getProto <$> G.nonStreaming grpcExporter.connection (G.rpc @(G.Protobuf serv meth)) (G.Proto input)
 
 --------------------------------------------------------------------------------
 -- OTLP HTTP/Protobuf Exporter
 --------------------------------------------------------------------------------
 
-data HttpProtobufExporter = HttpProtobufExporter
+{- |
+The options for an OTLP HTTP/Protobuf endpoint.
+-}
+data OtlpEndpointHttp = OtlpEndpointHttp
+  { otlpHttpHost :: !String
+  , otlpHttpPort :: !Integer
+  , otlpHttpSecure :: !Bool
+  , otlpHttpPath :: !String
+  , otlpHttpParams :: ![(String, String)]
+  }
+  deriving (Show)
+
+data OtlpHttpProtobufExporter = OtlpHttpProtobufExporter
   { manager :: H.Manager
   , baseUrl :: String
   , headers :: HTTP.RequestHeaders
   }
 
-data HttpProtobufError
-  = HttpProtobufStatusError
+data HttpError
+  = HttpStatusError
       { statusCode :: Int
       , statusMessage :: ByteString
       , responseBody :: ByteString
       }
-  | HttpProtobufDecodeError
+  | HttpDecodeError
       { errorMessage :: String
       }
   deriving (Show)
 
-instance Exception HttpProtobufError where
-  displayException :: HttpProtobufError -> String
+instance Exception HttpError where
+  displayException :: HttpError -> String
   displayException = \case
-    HttpProtobufStatusError{..} ->
-      printf
-        "Error: OpenTelemetry Collector HTTP/Protobuf endpoint returned status %d %s with body: %s"
-        statusCode
-        (BSC.unpack statusMessage)
-        (BSC.unpack responseBody)
-    HttpProtobufDecodeError{..} ->
-      "Error: Could not decode OpenTelemetry Collector HTTP/Protobuf response: " <> errorMessage
-
-{- |
-Internal helper.
--}
-makeHttpProtobufExporter :: H.Manager -> HttpProtobufOptions -> HttpProtobufExporter
-makeHttpProtobufExporter manager HttpProtobufOptions{..} =
-  HttpProtobufExporter
-    { manager = manager
-    , baseUrl = httpProtobufScheme <> "://" <> httpProtobufHost <> ":" <> show httpProtobufPort
-    , headers = makeRequestHeaders httpProtobufHeaders
-    }
+    HttpStatusError{..} ->
+      "OpenTelemetry Collector HTTP/Protobuf endpoint returned status "
+        <> show statusCode
+        <> " "
+        <> BSC.unpack statusMessage
+        <> " with body: "
+        <> BSC.unpack responseBody
+    HttpDecodeError{..} ->
+      "Could not decode OpenTelemetry Collector HTTP/Protobuf response: "
+        <> errorMessage
 
 {- |
 Internal helper.
 
-Convert a list of t`HttpHeader` headers to `HTTP.RequestHeaders`.
+Run an action with an t`OtlpHttpProtobufExporter`.
 -}
-makeRequestHeaders :: [HttpHeader] -> HTTP.RequestHeaders
-makeRequestHeaders httpHeaders =
-  [ (CI.mk (BSC.pack httpHeaderName), BSC.pack httpHeaderValue)
-  | HttpHeader{..} <- httpHeaders
-  ]
+withOtlpHttpProtobufExporter :: OtlpExporterOptions OtlpEndpointHttp -> (OtlpHttpProtobufExporter -> IO a) -> IO a
+withOtlpHttpProtobufExporter OtlpExporterOptions{otlpEndpoint = OtlpEndpointHttp{..}, ..} action = do
+  -- Create an HTTP manager.
+  manager <- H.newManager H.tlsManagerSettings
+  -- Create the HTTP baseUrl.
+  let baseUrlType = URL.Absolute URL.Host{protocol = URL.HTTP otlpHttpSecure, host = otlpHttpHost, port = Just otlpHttpPort}
+  let baseUrl = URL.URL{url_type = baseUrlType, url_path = otlpHttpPath, url_params = otlpHttpParams}
+  -- Create the HTTP headers.
+  let headers = [(CI.mk (BSC.pack name), BSC.pack value) | (name, value) <- fromMaybe [] otlpHttpHeaders]
+  -- Create the HTTP/Protobuf exporter.
+  let exporter = OtlpHttpProtobufExporter{manager = manager, baseUrl = URL.exportURL baseUrl, headers = headers}
+  -- Run the action.
+  action exporter
 
 class
   ( Message (MethodInput serv meth)
@@ -225,15 +279,15 @@ class
 {- |
 Send a Protobuf message over an HTTP connection.
 -}
-sendHttpProtobuf ::
+exportHttpProtobuf ::
   forall serv meth.
   (CanExportViaHttpProtobuf serv meth) =>
   -- | The HTTP/Protobuf exporter.
-  HttpProtobufExporter ->
+  OtlpHttpProtobufExporter ->
   -- | The request message.
   MethodInput serv meth ->
   IO (MethodOutput serv meth)
-sendHttpProtobuf HttpProtobufExporter{..} req = do
+exportHttpProtobuf OtlpHttpProtobufExporter{..} req = do
   baseRequest <- H.parseRequest (baseUrl <> apiPath @serv @meth)
   let request =
         baseRequest
@@ -253,7 +307,7 @@ sendHttpProtobuf HttpProtobufExporter{..} req = do
     then decodeResponseBody body
     else
       throwIO
-        HttpProtobufStatusError
+        HttpStatusError
           { statusCode = HTTP.statusCode status
           , statusMessage = HTTP.statusMessage status
           , responseBody = body
@@ -269,5 +323,5 @@ decodeResponseBody body
   | BS.null body = pure defMessage
   | otherwise =
       case Proto.decodeMessage body of
-        Left errorMessage -> throwIO HttpProtobufDecodeError{..}
+        Left errorMessage -> throwIO HttpDecodeError{..}
         Right msg -> pure msg

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Logs.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Logs.hs
@@ -16,6 +16,7 @@ import Data.Semigroup (Sum (..))
 import Data.Text (Text)
 import Data.Vector qualified as V
 import GHC.Eventlog.Live.Machine.Core (Tick (..))
+import GHC.Eventlog.Live.Otelcol.Exporter.Core (OpenTelemetryExporter (..), sendHttpProtobuf)
 import Lens.Family2 ((^.))
 import Network.GRPC.Client qualified as G
 import Network.GRPC.Client.StreamType.IO qualified as G
@@ -67,9 +68,9 @@ instance Exception RejectedLogsError where
 -- OpenTelemetry gRPC Exporter for Logs
 
 exportResourceLogs ::
-  G.Connection ->
+  OpenTelemetryExporter ->
   ProcessT IO (Tick OLS.ExportLogsServiceRequest) (Tick ExportLogsResult)
-exportResourceLogs conn = construct $ go False
+exportResourceLogs exporter = construct $ go False
  where
   go exportedResourceLogs =
     await >>= \case
@@ -91,7 +92,7 @@ exportResourceLogs conn = construct $ go False
 
     doGrpc :: IO ExportLogsResult
     doGrpc = do
-      G.nonStreaming conn (G.rpc @(Protobuf OLS.LogsService "export")) (G.Proto exportLogsServiceRequest) >>= \case
+      sendExportLogsServiceRequest exportLogsServiceRequest >>= \case
         G.Proto resp
           | resp ^. OLS.partialSuccess . OLS.rejectedLogRecords == 0 -> do
               pure $ ExportLogsSuccess exportedLogRecords
@@ -102,6 +103,16 @@ exportResourceLogs conn = construct $ go False
 
     handleSomeException :: SomeException -> IO ExportLogsResult
     handleSomeException someException = pure $ ExportLogsError 0 exportedLogRecords someException
+
+  sendExportLogsServiceRequest ::
+    OLS.ExportLogsServiceRequest ->
+    IO (G.Proto OLS.ExportLogsServiceResponse)
+  sendExportLogsServiceRequest exportLogsServiceRequest =
+    case exporter of
+      OpenTelemetryExporter'Grpc conn ->
+        G.nonStreaming conn (G.rpc @(Protobuf OLS.LogsService "export")) (G.Proto exportLogsServiceRequest)
+      OpenTelemetryExporter'Http httpProtobufExporter ->
+        G.Proto <$> sendHttpProtobuf httpProtobufExporter "/v1/logs" exportLogsServiceRequest
 
 type instance G.RequestMetadata (Protobuf OLS.LogsService meth) = G.NoMetadata
 type instance G.ResponseInitialMetadata (Protobuf OLS.LogsService meth) = G.NoMetadata

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Logs.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Logs.hs
@@ -16,13 +16,10 @@ import Data.Semigroup (Sum (..))
 import Data.Text (Text)
 import Data.Vector qualified as V
 import GHC.Eventlog.Live.Machine.Core (Tick (..))
-import GHC.Eventlog.Live.Otelcol.Exporter.Core (OpenTelemetryExporter (..), sendHttpProtobuf)
+import GHC.Eventlog.Live.Otelcol.Exporter.Core (CanExportViaHttpProtobuf (..), OpenTelemetryExporter (..), export)
 import Lens.Family2 ((^.))
-import Network.GRPC.Client qualified as G
-import Network.GRPC.Client.StreamType.IO qualified as G
 import Network.GRPC.Common qualified as G
 import Network.GRPC.Common.Protobuf (Protobuf)
-import Network.GRPC.Common.Protobuf qualified as G
 import Proto.Opentelemetry.Proto.Collector.Logs.V1.LogsService qualified as OLS
 import Proto.Opentelemetry.Proto.Collector.Logs.V1.LogsService_Fields qualified as OLS
 import Proto.Opentelemetry.Proto.Logs.V1.Logs qualified as OL
@@ -86,37 +83,31 @@ exportResourceLogs exporter = construct $ go False
 
   sendResourceLogs :: OLS.ExportLogsServiceRequest -> IO ExportLogsResult
   sendResourceLogs exportLogsServiceRequest =
-    doGrpc `catch` handleSomeException
+    doExport `catch` handleSomeException
    where
     !exportedLogRecords = countLogRecordsInExportLogsServiceRequest exportLogsServiceRequest
 
-    doGrpc :: IO ExportLogsResult
-    doGrpc = do
-      sendExportLogsServiceRequest exportLogsServiceRequest >>= \case
-        G.Proto resp
-          | resp ^. OLS.partialSuccess . OLS.rejectedLogRecords == 0 -> do
-              pure $ ExportLogsSuccess exportedLogRecords
-          | otherwise -> do
-              let !rejectedLogRecords = resp ^. OLS.partialSuccess . OLS.rejectedLogRecords
-              let !rejectedLogsError = RejectedLogsError{errorMessage = resp ^. OLS.partialSuccess . OLS.errorMessage, ..}
-              pure $ ExportLogsError exportedLogRecords rejectedLogRecords (SomeException rejectedLogsError)
+    doExport :: IO ExportLogsResult
+    doExport = do
+      resp <- export @OLS.LogsService @"export" exporter exportLogsServiceRequest
+      if resp ^. OLS.partialSuccess . OLS.rejectedLogRecords == 0
+        then
+          pure $ ExportLogsSuccess exportedLogRecords
+        else do
+          let !rejectedLogRecords = resp ^. OLS.partialSuccess . OLS.rejectedLogRecords
+          let !rejectedLogsError = RejectedLogsError{errorMessage = resp ^. OLS.partialSuccess . OLS.errorMessage, ..}
+          pure $ ExportLogsError exportedLogRecords rejectedLogRecords (SomeException rejectedLogsError)
 
     handleSomeException :: SomeException -> IO ExportLogsResult
     handleSomeException someException = pure $ ExportLogsError 0 exportedLogRecords someException
 
-  sendExportLogsServiceRequest ::
-    OLS.ExportLogsServiceRequest ->
-    IO (G.Proto OLS.ExportLogsServiceResponse)
-  sendExportLogsServiceRequest exportLogsServiceRequest =
-    case exporter of
-      OpenTelemetryExporter'Grpc conn ->
-        G.nonStreaming conn (G.rpc @(Protobuf OLS.LogsService "export")) (G.Proto exportLogsServiceRequest)
-      OpenTelemetryExporter'Http httpProtobufExporter ->
-        G.Proto <$> sendHttpProtobuf httpProtobufExporter "/v1/logs" exportLogsServiceRequest
-
 type instance G.RequestMetadata (Protobuf OLS.LogsService meth) = G.NoMetadata
 type instance G.ResponseInitialMetadata (Protobuf OLS.LogsService meth) = G.NoMetadata
 type instance G.ResponseTrailingMetadata (Protobuf OLS.LogsService meth) = G.NoMetadata
+
+instance CanExportViaHttpProtobuf OLS.LogsService "export" where
+  apiPath :: String
+  apiPath = "/v1/logs"
 
 --------------------------------------------------------------------------------
 -- Internal Helpers

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Logs.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Logs.hs
@@ -16,7 +16,7 @@ import Data.Semigroup (Sum (..))
 import Data.Text (Text)
 import Data.Vector qualified as V
 import GHC.Eventlog.Live.Machine.Core (Tick (..))
-import GHC.Eventlog.Live.Otelcol.Exporter.Core (CanExportViaHttpProtobuf (..), OpenTelemetryExporter (..), export)
+import GHC.Eventlog.Live.Otelcol.Exporter.Core (CanExportViaHttpProtobuf (..), OtlpExporter (..), export)
 import Lens.Family2 ((^.))
 import Network.GRPC.Common qualified as G
 import Network.GRPC.Common.Protobuf (Protobuf)
@@ -65,7 +65,7 @@ instance Exception RejectedLogsError where
 -- OpenTelemetry gRPC Exporter for Logs
 
 exportResourceLogs ::
-  OpenTelemetryExporter ->
+  OtlpExporter ->
   ProcessT IO (Tick OLS.ExportLogsServiceRequest) (Tick ExportLogsResult)
 exportResourceLogs exporter = construct $ go False
  where

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Metrics.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Metrics.hs
@@ -16,13 +16,10 @@ import Data.Semigroup (Sum (..))
 import Data.Text (Text)
 import Data.Vector qualified as V
 import GHC.Eventlog.Live.Machine.Core (Tick (..))
-import GHC.Eventlog.Live.Otelcol.Exporter.Core (OpenTelemetryExporter (..), sendHttpProtobuf)
+import GHC.Eventlog.Live.Otelcol.Exporter.Core (CanExportViaHttpProtobuf (..), OpenTelemetryExporter (..), export)
 import Lens.Family2 ((^.))
-import Network.GRPC.Client qualified as G
-import Network.GRPC.Client.StreamType.IO qualified as G
 import Network.GRPC.Common qualified as G
 import Network.GRPC.Common.Protobuf (Protobuf)
-import Network.GRPC.Common.Protobuf qualified as G
 import Proto.Opentelemetry.Proto.Collector.Metrics.V1.MetricsService qualified as OMS
 import Proto.Opentelemetry.Proto.Collector.Metrics.V1.MetricsService_Fields qualified as OMS
 import Proto.Opentelemetry.Proto.Metrics.V1.Metrics qualified as OM
@@ -86,40 +83,31 @@ exportResourceMetrics exporter = construct $ go False
 
   sendResourceMetrics :: OMS.ExportMetricsServiceRequest -> IO ExportMetricsResult
   sendResourceMetrics exportMetricsServiceRequest =
-    doGrpc `catch` handleSomeException
+    doExport `catch` handleSomeException
    where
     !exportedDataPoints = countDataPointsInExportMetricsServiceRequest exportMetricsServiceRequest
 
-    doGrpc :: IO ExportMetricsResult
-    doGrpc = do
-      sendExportMetricsServiceRequest exportMetricsServiceRequest >>= \case
-        G.Proto resp
-          | resp ^. OMS.partialSuccess . OMS.rejectedDataPoints == 0 -> do
-              pure $ ExportMetricsSuccess exportedDataPoints
-          | otherwise -> do
-              let !rejectedDataPoints = resp ^. OMS.partialSuccess . OMS.rejectedDataPoints
-              let !rejectedMetricsError = RejectedMetricsError{errorMessage = resp ^. OMS.partialSuccess . OMS.errorMessage, ..}
-              pure $ ExportMetricsError exportedDataPoints rejectedDataPoints (SomeException rejectedMetricsError)
-
-    -- handleGrpcError :: G.GrpcError -> IO ExportMetricsResult
-    -- handleGrpcError grpcError = pure $ ExportMetricsError 0 exportedDataPoints (SomeException grpcError)
+    doExport :: IO ExportMetricsResult
+    doExport = do
+      resp <- export @OMS.MetricsService @"export" exporter exportMetricsServiceRequest
+      if resp ^. OMS.partialSuccess . OMS.rejectedDataPoints == 0
+        then
+          pure $ ExportMetricsSuccess exportedDataPoints
+        else do
+          let !rejectedDataPoints = resp ^. OMS.partialSuccess . OMS.rejectedDataPoints
+          let !rejectedMetricsError = RejectedMetricsError{errorMessage = resp ^. OMS.partialSuccess . OMS.errorMessage, ..}
+          pure $ ExportMetricsError exportedDataPoints rejectedDataPoints (SomeException rejectedMetricsError)
 
     handleSomeException :: SomeException -> IO ExportMetricsResult
     handleSomeException someException = pure $ ExportMetricsError 0 exportedDataPoints someException
 
-  sendExportMetricsServiceRequest ::
-    OMS.ExportMetricsServiceRequest ->
-    IO (G.Proto OMS.ExportMetricsServiceResponse)
-  sendExportMetricsServiceRequest exportMetricsServiceRequest =
-    case exporter of
-      OpenTelemetryExporter'Grpc conn ->
-        G.nonStreaming conn (G.rpc @(Protobuf OMS.MetricsService "export")) (G.Proto exportMetricsServiceRequest)
-      OpenTelemetryExporter'Http httpProtobufExporter ->
-        G.Proto <$> sendHttpProtobuf httpProtobufExporter "/v1/metrics" exportMetricsServiceRequest
-
 type instance G.RequestMetadata (Protobuf OMS.MetricsService meth) = G.NoMetadata
 type instance G.ResponseInitialMetadata (Protobuf OMS.MetricsService meth) = G.NoMetadata
 type instance G.ResponseTrailingMetadata (Protobuf OMS.MetricsService meth) = G.NoMetadata
+
+instance CanExportViaHttpProtobuf OMS.MetricsService "export" where
+  apiPath :: String
+  apiPath = "/v1/metrics"
 
 --------------------------------------------------------------------------------
 -- Internal Helpers

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Metrics.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Metrics.hs
@@ -16,6 +16,7 @@ import Data.Semigroup (Sum (..))
 import Data.Text (Text)
 import Data.Vector qualified as V
 import GHC.Eventlog.Live.Machine.Core (Tick (..))
+import GHC.Eventlog.Live.Otelcol.Exporter.Core (OpenTelemetryExporter (..), sendHttpProtobuf)
 import Lens.Family2 ((^.))
 import Network.GRPC.Client qualified as G
 import Network.GRPC.Client.StreamType.IO qualified as G
@@ -67,9 +68,9 @@ instance Exception RejectedMetricsError where
 -- OpenTelemetry gRPC Exporter for Metrics
 
 exportResourceMetrics ::
-  G.Connection ->
+  OpenTelemetryExporter ->
   ProcessT IO (Tick OMS.ExportMetricsServiceRequest) (Tick ExportMetricsResult)
-exportResourceMetrics conn = construct $ go False
+exportResourceMetrics exporter = construct $ go False
  where
   go exportedResourceMetrics =
     await >>= \case
@@ -91,7 +92,7 @@ exportResourceMetrics conn = construct $ go False
 
     doGrpc :: IO ExportMetricsResult
     doGrpc = do
-      G.nonStreaming conn (G.rpc @(Protobuf OMS.MetricsService "export")) (G.Proto exportMetricsServiceRequest) >>= \case
+      sendExportMetricsServiceRequest exportMetricsServiceRequest >>= \case
         G.Proto resp
           | resp ^. OMS.partialSuccess . OMS.rejectedDataPoints == 0 -> do
               pure $ ExportMetricsSuccess exportedDataPoints
@@ -105,6 +106,16 @@ exportResourceMetrics conn = construct $ go False
 
     handleSomeException :: SomeException -> IO ExportMetricsResult
     handleSomeException someException = pure $ ExportMetricsError 0 exportedDataPoints someException
+
+  sendExportMetricsServiceRequest ::
+    OMS.ExportMetricsServiceRequest ->
+    IO (G.Proto OMS.ExportMetricsServiceResponse)
+  sendExportMetricsServiceRequest exportMetricsServiceRequest =
+    case exporter of
+      OpenTelemetryExporter'Grpc conn ->
+        G.nonStreaming conn (G.rpc @(Protobuf OMS.MetricsService "export")) (G.Proto exportMetricsServiceRequest)
+      OpenTelemetryExporter'Http httpProtobufExporter ->
+        G.Proto <$> sendHttpProtobuf httpProtobufExporter "/v1/metrics" exportMetricsServiceRequest
 
 type instance G.RequestMetadata (Protobuf OMS.MetricsService meth) = G.NoMetadata
 type instance G.ResponseInitialMetadata (Protobuf OMS.MetricsService meth) = G.NoMetadata

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Metrics.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Metrics.hs
@@ -16,7 +16,7 @@ import Data.Semigroup (Sum (..))
 import Data.Text (Text)
 import Data.Vector qualified as V
 import GHC.Eventlog.Live.Machine.Core (Tick (..))
-import GHC.Eventlog.Live.Otelcol.Exporter.Core (CanExportViaHttpProtobuf (..), OpenTelemetryExporter (..), export)
+import GHC.Eventlog.Live.Otelcol.Exporter.Core (CanExportViaHttpProtobuf (..), OtlpExporter (..), export)
 import Lens.Family2 ((^.))
 import Network.GRPC.Common qualified as G
 import Network.GRPC.Common.Protobuf (Protobuf)
@@ -65,7 +65,7 @@ instance Exception RejectedMetricsError where
 -- OpenTelemetry gRPC Exporter for Metrics
 
 exportResourceMetrics ::
-  OpenTelemetryExporter ->
+  OtlpExporter ->
   ProcessT IO (Tick OMS.ExportMetricsServiceRequest) (Tick ExportMetricsResult)
 exportResourceMetrics exporter = construct $ go False
  where

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Profiles.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Profiles.hs
@@ -17,6 +17,7 @@ import Data.Semigroup (Sum (..))
 import Data.Text (Text)
 import Data.Vector qualified as V
 import GHC.Eventlog.Live.Machine.Core (Tick (..))
+import GHC.Eventlog.Live.Otelcol.Exporter.Core (OpenTelemetryExporter (..), sendHttpProtobuf)
 import Lens.Family2 ((^.))
 import Network.GRPC.Client qualified as G
 import Network.GRPC.Client.StreamType.IO qualified as G
@@ -61,9 +62,9 @@ instance Exception RejectedProfilesError where
 -- OpenTelemetry gRPC Exporter for Profiles
 
 exportResourceProfiles ::
-  G.Connection ->
+  OpenTelemetryExporter ->
   ProcessT IO (Tick OPS.ExportProfilesServiceRequest) (Tick ExportProfileResult)
-exportResourceProfiles conn =
+exportResourceProfiles exporter =
   construct $ go False
  where
   go exportedProfiles =
@@ -86,7 +87,7 @@ exportResourceProfiles conn =
 
     doGrpc :: IO ExportProfileResult
     doGrpc = do
-      G.nonStreaming conn (G.rpc @(Protobuf OPS.ProfilesService "export")) (G.Proto exportProfilesServiceRequest) >>= \case
+      sendExportProfilesServiceRequest exportProfilesServiceRequest >>= \case
         G.Proto resp
           | resp ^. OPS.partialSuccess . OPS.rejectedProfiles == 0 ->
               pure $ ExportProfileSuccess exportedProfiles
@@ -97,6 +98,16 @@ exportResourceProfiles conn =
 
     handleSomeException :: SomeException -> IO ExportProfileResult
     handleSomeException someException = pure $ ExportProfileError 0 exportedProfiles someException
+
+  sendExportProfilesServiceRequest ::
+    OPS.ExportProfilesServiceRequest ->
+    IO (G.Proto OPS.ExportProfilesServiceResponse)
+  sendExportProfilesServiceRequest exportProfilesServiceRequest =
+    case exporter of
+      OpenTelemetryExporter'Grpc conn ->
+        G.nonStreaming conn (G.rpc @(Protobuf OPS.ProfilesService "export")) (G.Proto exportProfilesServiceRequest)
+      OpenTelemetryExporter'Http httpProtobufExporter ->
+        G.Proto <$> sendHttpProtobuf httpProtobufExporter "/v1development/profiles" exportProfilesServiceRequest
 
 type instance G.RequestMetadata (Protobuf OPS.ProfilesService meth) = G.NoMetadata
 

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Profiles.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Profiles.hs
@@ -17,13 +17,10 @@ import Data.Semigroup (Sum (..))
 import Data.Text (Text)
 import Data.Vector qualified as V
 import GHC.Eventlog.Live.Machine.Core (Tick (..))
-import GHC.Eventlog.Live.Otelcol.Exporter.Core (OpenTelemetryExporter (..), sendHttpProtobuf)
+import GHC.Eventlog.Live.Otelcol.Exporter.Core (CanExportViaHttpProtobuf (..), OpenTelemetryExporter (..), export)
 import Lens.Family2 ((^.))
-import Network.GRPC.Client qualified as G
-import Network.GRPC.Client.StreamType.IO qualified as G
 import Network.GRPC.Common qualified as G
 import Network.GRPC.Common.Protobuf (Protobuf)
-import Network.GRPC.Common.Protobuf qualified as G
 import Proto.Opentelemetry.Proto.Collector.Profiles.V1development.ProfilesService qualified as OPS
 import Proto.Opentelemetry.Proto.Collector.Profiles.V1development.ProfilesService_Fields qualified as OPS
 import Proto.Opentelemetry.Proto.Profiles.V1development.Profiles qualified as OP
@@ -81,39 +78,31 @@ exportResourceProfiles exporter =
 
   sendResourceProfiles :: OPS.ExportProfilesServiceRequest -> IO ExportProfileResult
   sendResourceProfiles exportProfilesServiceRequest =
-    doGrpc `catch` handleSomeException
+    doExport `catch` handleSomeException
    where
     !exportedProfiles = countSamplesInExportProfileServiceRequest exportProfilesServiceRequest
 
-    doGrpc :: IO ExportProfileResult
-    doGrpc = do
-      sendExportProfilesServiceRequest exportProfilesServiceRequest >>= \case
-        G.Proto resp
-          | resp ^. OPS.partialSuccess . OPS.rejectedProfiles == 0 ->
-              pure $ ExportProfileSuccess exportedProfiles
-          | otherwise -> do
-              let !rejectedProfiles = resp ^. OPS.partialSuccess . OPS.rejectedProfiles
-              let !rejectedMetricsError = RejectedProfilesError{errorMessage = resp ^. OPS.partialSuccess . OPS.errorMessage, ..}
-              pure $ ExportProfileError exportedProfiles rejectedProfiles (SomeException rejectedMetricsError)
+    doExport :: IO ExportProfileResult
+    doExport = do
+      resp <- export @OPS.ProfilesService @"export" exporter exportProfilesServiceRequest
+      if resp ^. OPS.partialSuccess . OPS.rejectedProfiles == 0
+        then
+          pure $ ExportProfileSuccess exportedProfiles
+        else do
+          let !rejectedProfiles = resp ^. OPS.partialSuccess . OPS.rejectedProfiles
+          let !rejectedMetricsError = RejectedProfilesError{errorMessage = resp ^. OPS.partialSuccess . OPS.errorMessage, ..}
+          pure $ ExportProfileError exportedProfiles rejectedProfiles (SomeException rejectedMetricsError)
 
     handleSomeException :: SomeException -> IO ExportProfileResult
     handleSomeException someException = pure $ ExportProfileError 0 exportedProfiles someException
 
-  sendExportProfilesServiceRequest ::
-    OPS.ExportProfilesServiceRequest ->
-    IO (G.Proto OPS.ExportProfilesServiceResponse)
-  sendExportProfilesServiceRequest exportProfilesServiceRequest =
-    case exporter of
-      OpenTelemetryExporter'Grpc conn ->
-        G.nonStreaming conn (G.rpc @(Protobuf OPS.ProfilesService "export")) (G.Proto exportProfilesServiceRequest)
-      OpenTelemetryExporter'Http httpProtobufExporter ->
-        G.Proto <$> sendHttpProtobuf httpProtobufExporter "/v1development/profiles" exportProfilesServiceRequest
-
 type instance G.RequestMetadata (Protobuf OPS.ProfilesService meth) = G.NoMetadata
-
 type instance G.ResponseInitialMetadata (Protobuf OPS.ProfilesService meth) = G.NoMetadata
-
 type instance G.ResponseTrailingMetadata (Protobuf OPS.ProfilesService meth) = G.NoMetadata
+
+instance CanExportViaHttpProtobuf OPS.ProfilesService "export" where
+  apiPath :: String
+  apiPath = "/v1development/profiles"
 
 {- |
 Internal helper.

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Profiles.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Profiles.hs
@@ -17,7 +17,7 @@ import Data.Semigroup (Sum (..))
 import Data.Text (Text)
 import Data.Vector qualified as V
 import GHC.Eventlog.Live.Machine.Core (Tick (..))
-import GHC.Eventlog.Live.Otelcol.Exporter.Core (CanExportViaHttpProtobuf (..), OpenTelemetryExporter (..), export)
+import GHC.Eventlog.Live.Otelcol.Exporter.Core (CanExportViaHttpProtobuf (..), OtlpExporter (..), export)
 import Lens.Family2 ((^.))
 import Network.GRPC.Common qualified as G
 import Network.GRPC.Common.Protobuf (Protobuf)
@@ -59,7 +59,7 @@ instance Exception RejectedProfilesError where
 -- OpenTelemetry gRPC Exporter for Profiles
 
 exportResourceProfiles ::
-  OpenTelemetryExporter ->
+  OtlpExporter ->
   ProcessT IO (Tick OPS.ExportProfilesServiceRequest) (Tick ExportProfileResult)
 exportResourceProfiles exporter =
   construct $ go False

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Traces.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Traces.hs
@@ -16,13 +16,10 @@ import Data.Semigroup (Sum (..))
 import Data.Text (Text)
 import Data.Vector qualified as V
 import GHC.Eventlog.Live.Machine.Core (Tick (..))
-import GHC.Eventlog.Live.Otelcol.Exporter.Core (OpenTelemetryExporter (..), sendHttpProtobuf)
+import GHC.Eventlog.Live.Otelcol.Exporter.Core (CanExportViaHttpProtobuf (..), OpenTelemetryExporter (..), export)
 import Lens.Family2 ((^.))
-import Network.GRPC.Client qualified as G
-import Network.GRPC.Client.StreamType.IO qualified as G
 import Network.GRPC.Common qualified as G
 import Network.GRPC.Common.Protobuf (Protobuf)
-import Network.GRPC.Common.Protobuf qualified as G
 import Proto.Opentelemetry.Proto.Collector.Trace.V1.TraceService qualified as OTS
 import Proto.Opentelemetry.Proto.Collector.Trace.V1.TraceService_Fields qualified as OTS
 import Proto.Opentelemetry.Proto.Trace.V1.Trace qualified as OT
@@ -89,31 +86,25 @@ exportResourceSpans exporter =
 
     doGrpc :: IO ExportTraceResult
     doGrpc = do
-      sendExportTraceServiceRequest exportTraceServiceRequest >>= \case
-        G.Proto resp
-          | resp ^. OTS.partialSuccess . OTS.rejectedSpans == 0 ->
-              pure $ ExportTraceSuccess exportedSpans
-          | otherwise -> do
-              let !rejectedSpans = resp ^. OTS.partialSuccess . OTS.rejectedSpans
-              let !rejectedMetricsError = RejectedSpansError{errorMessage = resp ^. OTS.partialSuccess . OTS.errorMessage, ..}
-              pure $ ExportTraceError exportedSpans rejectedSpans (SomeException rejectedMetricsError)
+      resp <- export @OTS.TraceService @"export" exporter exportTraceServiceRequest
+      if resp ^. OTS.partialSuccess . OTS.rejectedSpans == 0
+        then
+          pure $ ExportTraceSuccess exportedSpans
+        else do
+          let !rejectedSpans = resp ^. OTS.partialSuccess . OTS.rejectedSpans
+          let !rejectedMetricsError = RejectedSpansError{errorMessage = resp ^. OTS.partialSuccess . OTS.errorMessage, ..}
+          pure $ ExportTraceError exportedSpans rejectedSpans (SomeException rejectedMetricsError)
 
     handleSomeException :: SomeException -> IO ExportTraceResult
     handleSomeException someException = pure $ ExportTraceError 0 exportedSpans someException
 
-  sendExportTraceServiceRequest ::
-    OTS.ExportTraceServiceRequest ->
-    IO (G.Proto OTS.ExportTraceServiceResponse)
-  sendExportTraceServiceRequest exportTraceServiceRequest =
-    case exporter of
-      OpenTelemetryExporter'Grpc conn ->
-        G.nonStreaming conn (G.rpc @(Protobuf OTS.TraceService "export")) (G.Proto exportTraceServiceRequest)
-      OpenTelemetryExporter'Http httpProtobufExporter ->
-        G.Proto <$> sendHttpProtobuf httpProtobufExporter "/v1/traces" exportTraceServiceRequest
-
 type instance G.RequestMetadata (Protobuf OTS.TraceService meth) = G.NoMetadata
 type instance G.ResponseInitialMetadata (Protobuf OTS.TraceService meth) = G.NoMetadata
 type instance G.ResponseTrailingMetadata (Protobuf OTS.TraceService meth) = G.NoMetadata
+
+instance CanExportViaHttpProtobuf OTS.TraceService "export" where
+  apiPath :: String
+  apiPath = "/v1/traces"
 
 --------------------------------------------------------------------------------
 -- Internal Helpers

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Traces.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Traces.hs
@@ -16,7 +16,7 @@ import Data.Semigroup (Sum (..))
 import Data.Text (Text)
 import Data.Vector qualified as V
 import GHC.Eventlog.Live.Machine.Core (Tick (..))
-import GHC.Eventlog.Live.Otelcol.Exporter.Core (CanExportViaHttpProtobuf (..), OpenTelemetryExporter (..), export)
+import GHC.Eventlog.Live.Otelcol.Exporter.Core (CanExportViaHttpProtobuf (..), OtlpExporter (..), export)
 import Lens.Family2 ((^.))
 import Network.GRPC.Common qualified as G
 import Network.GRPC.Common.Protobuf (Protobuf)
@@ -61,7 +61,7 @@ instance Exception RejectedSpansError where
 -- OpenTelemetry gRPC Exporter for Traces
 
 exportResourceSpans ::
-  OpenTelemetryExporter ->
+  OtlpExporter ->
   ProcessT IO (Tick OTS.ExportTraceServiceRequest) (Tick ExportTraceResult)
 exportResourceSpans exporter =
   construct $ go False

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Traces.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Exporter/Traces.hs
@@ -16,6 +16,7 @@ import Data.Semigroup (Sum (..))
 import Data.Text (Text)
 import Data.Vector qualified as V
 import GHC.Eventlog.Live.Machine.Core (Tick (..))
+import GHC.Eventlog.Live.Otelcol.Exporter.Core (OpenTelemetryExporter (..), sendHttpProtobuf)
 import Lens.Family2 ((^.))
 import Network.GRPC.Client qualified as G
 import Network.GRPC.Client.StreamType.IO qualified as G
@@ -63,9 +64,9 @@ instance Exception RejectedSpansError where
 -- OpenTelemetry gRPC Exporter for Traces
 
 exportResourceSpans ::
-  G.Connection ->
+  OpenTelemetryExporter ->
   ProcessT IO (Tick OTS.ExportTraceServiceRequest) (Tick ExportTraceResult)
-exportResourceSpans conn =
+exportResourceSpans exporter =
   construct $ go False
  where
   go exportedResourceSpans =
@@ -88,7 +89,7 @@ exportResourceSpans conn =
 
     doGrpc :: IO ExportTraceResult
     doGrpc = do
-      G.nonStreaming conn (G.rpc @(Protobuf OTS.TraceService "export")) (G.Proto exportTraceServiceRequest) >>= \case
+      sendExportTraceServiceRequest exportTraceServiceRequest >>= \case
         G.Proto resp
           | resp ^. OTS.partialSuccess . OTS.rejectedSpans == 0 ->
               pure $ ExportTraceSuccess exportedSpans
@@ -99,6 +100,16 @@ exportResourceSpans conn =
 
     handleSomeException :: SomeException -> IO ExportTraceResult
     handleSomeException someException = pure $ ExportTraceError 0 exportedSpans someException
+
+  sendExportTraceServiceRequest ::
+    OTS.ExportTraceServiceRequest ->
+    IO (G.Proto OTS.ExportTraceServiceResponse)
+  sendExportTraceServiceRequest exportTraceServiceRequest =
+    case exporter of
+      OpenTelemetryExporter'Grpc conn ->
+        G.nonStreaming conn (G.rpc @(Protobuf OTS.TraceService "export")) (G.Proto exportTraceServiceRequest)
+      OpenTelemetryExporter'Http httpProtobufExporter ->
+        G.Proto <$> sendHttpProtobuf httpProtobufExporter "/v1/traces" exportTraceServiceRequest
 
 type instance G.RequestMetadata (Protobuf OTS.TraceService meth) = G.NoMetadata
 type instance G.ResponseInitialMetadata (Protobuf OTS.TraceService meth) = G.NoMetadata

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Options.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Options.hs
@@ -199,11 +199,11 @@ otelcolProtocolParser =
   O.option
     ( O.eitherReader $ \case
         "grpc" -> Right OpenTelemetryCollectorProtocol'Grpc
-        "http-protobuf" -> Right OpenTelemetryCollectorProtocol'HttpProtobuf
+        "http/protobuf" -> Right OpenTelemetryCollectorProtocol'HttpProtobuf
         protocol -> Left $ "Unknown OpenTelemetry Collector protocol: " <> protocol
     )
     ( O.long "otelcol-protocol"
-        <> O.metavar "grpc|http-protobuf"
+        <> O.metavar "grpc|http/protobuf"
         <> O.help "OpenTelemetry Collector protocol."
         <> O.value OpenTelemetryCollectorProtocol'Grpc
         <> O.showDefaultWith (const "grpc")

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Options.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Options.hs
@@ -3,10 +3,12 @@ module GHC.Eventlog.Live.Otelcol.Options (
   MyDebugOptions (..),
   ServiceName (..),
   OpenTelemetryCollectorOptions (..),
+  OpenTelemetryCollectorProtocol (..),
+  HttpProtobufOptions (..),
+  HttpHeader (..),
   options,
 ) where
 
-import Control.Applicative (asum)
 import Data.Default (Default (..))
 import Data.Text qualified as T
 import Data.Version (showVersion)
@@ -21,7 +23,6 @@ import GHC.Eventlog.Live.Otelcol.Control (ControlOptions, controlOptionsParser)
 import GHC.Eventlog.Live.Source.Core (EventlogSourceOptions (..))
 import GHC.Eventlog.Socket.Compat (MyEventlogSocket (..), maybeMyEventlogSocketParser)
 import GHC.RTS.Events (HeapProfBreakdown (..))
-import Network.GRPC.Client qualified as G
 import Network.GRPC.Common qualified as G
 import Options.Applicative qualified as O
 import Options.Applicative.Compat qualified as OC
@@ -150,84 +151,121 @@ ccDBPathParser =
 --------------------------------------------------------------------------------
 -- OpenTelemetry Collector configuration
 
-newtype OpenTelemetryCollectorOptions = OpenTelemetryCollectorOptions
-  { openTelemetryCollectorServer :: G.Server
+data OpenTelemetryCollectorOptions = OpenTelemetryCollectorOptions
+  { openTelemetryCollectorProtocol :: OpenTelemetryCollectorProtocol
+  , otelcolHost :: String
+  , maybeOtelcolPort :: Maybe Int
+  , maybeOtelcolAuthority :: Maybe String
+  , otelcolSsl :: Bool
+  , maybeOtelcolCertificateStore :: Maybe FilePath
+  , maybeOtelcolSslKeyLog :: Maybe G.SslKeyLog
+  , otelcolHeaders :: [HttpHeader]
   }
+
+data OpenTelemetryCollectorProtocol
+  = OpenTelemetryCollectorProtocol'Grpc
+  | OpenTelemetryCollectorProtocol'HttpProtobuf
+  deriving (Eq, Show)
+
+data HttpProtobufOptions = HttpProtobufOptions
+  { httpProtobufScheme :: String
+  , httpProtobufHost :: String
+  , httpProtobufPort :: Int
+  , httpProtobufHeaders :: [HttpHeader]
+  }
+  deriving (Show)
+
+data HttpHeader = HttpHeader
+  { httpHeaderName :: String
+  , httpHeaderValue :: String
+  }
+  deriving (Show)
 
 openTelemetryCollectorOptionsParser :: O.Parser OpenTelemetryCollectorOptions
 openTelemetryCollectorOptionsParser =
   OC.parserOptionGroup "OpenTelemetry Collector Server Options" $
     OpenTelemetryCollectorOptions
-      <$> otelcolServerParser
+      <$> otelcolProtocolParser
+      <*> otelcolHostParser
+      <*> O.optional otelcolPortParser
+      <*> O.optional otelcolAuthorityParser
+      <*> O.switch (O.long "otelcol-ssl" <> O.help "Use SSL.")
+      <*> O.optional otelcolCertificateStoreParser
+      <*> O.optional otelcolSslKeyLogParser
+      <*> O.many otelcolHeaderParser
 
-otelcolServerParser :: O.Parser G.Server
-otelcolServerParser =
-  makeServer
-    <$> otelcolAddressParser
-    <*> O.switch (O.long "otelcol-ssl" <> O.help "Use SSL.")
-    <*> otelcolServerValidationParser
-    <*> otelcolSslKeyLogParser
- where
-  makeServer :: G.Address -> Bool -> G.ServerValidation -> G.SslKeyLog -> G.Server
-  makeServer address ssl serverValidation sslKeyLog
-    | ssl = G.ServerSecure serverValidation sslKeyLog address
-    | otherwise = G.ServerInsecure address
+otelcolProtocolParser :: O.Parser OpenTelemetryCollectorProtocol
+otelcolProtocolParser =
+  O.option
+    ( O.eitherReader $ \case
+        "grpc" -> Right OpenTelemetryCollectorProtocol'Grpc
+        "http-protobuf" -> Right OpenTelemetryCollectorProtocol'HttpProtobuf
+        protocol -> Left $ "Unknown OpenTelemetry Collector protocol: " <> protocol
+    )
+    ( O.long "otelcol-protocol"
+        <> O.metavar "grpc|http-protobuf"
+        <> O.help "OpenTelemetry Collector protocol."
+        <> O.value OpenTelemetryCollectorProtocol'Grpc
+        <> O.showDefaultWith (const "grpc")
+    )
 
-otelcolAddressParser :: O.Parser G.Address
-otelcolAddressParser =
-  G.Address
-    <$> O.strOption
-      ( O.long "otelcol-host"
-          <> O.metavar "HOST"
-          <> O.help "Otelcol server hostname."
-      )
-    <*> O.option
-      O.auto
-      ( O.long "otelcol-port"
-          <> O.metavar "PORT"
-          <> O.help "Otelcol server TCP port."
-          <> O.value 4317
-      )
-    <*> O.optional
-      ( O.strOption
-          ( O.long "otelcol-authority"
-              <> O.metavar "HOST"
-              <> O.help "Otelcol server authority."
-          )
-      )
+otelcolHostParser :: O.Parser String
+otelcolHostParser =
+  O.strOption
+    ( O.long "otelcol-host"
+        <> O.metavar "HOST"
+        <> O.help "Otelcol server hostname."
+    )
 
-otelcolServerValidationParser :: O.Parser G.ServerValidation
-otelcolServerValidationParser =
-  asum
-    [ G.ValidateServer <$> otelcolCertificateStoreSpecParser
-    , pure G.NoServerValidation
-    ]
- where
-  otelcolCertificateStoreSpecParser :: O.Parser G.CertificateStoreSpec
-  otelcolCertificateStoreSpecParser =
-    makeCertificateStoreSpec
-      <$> O.optional
-        ( O.strOption
-            ( O.long "otelcol-certificate-store"
-                <> O.metavar "FILE"
-                <> O.help "Store for certificate validation."
-            )
-        )
-   where
-    makeCertificateStoreSpec :: Maybe FilePath -> G.CertificateStoreSpec
-    makeCertificateStoreSpec = maybe G.certStoreFromSystem G.certStoreFromPath
+otelcolPortParser :: O.Parser Int
+otelcolPortParser =
+  O.option
+    O.auto
+    ( O.long "otelcol-port"
+        <> O.metavar "PORT"
+        <> O.help "Otelcol server TCP port. Defaults to 4317 for gRPC and 4318 for HTTP/protobuf."
+    )
+
+otelcolAuthorityParser :: O.Parser String
+otelcolAuthorityParser =
+  O.strOption
+    ( O.long "otelcol-authority"
+        <> O.metavar "HOST"
+        <> O.help "Otelcol server authority."
+    )
+
+otelcolCertificateStoreParser :: O.Parser FilePath
+otelcolCertificateStoreParser =
+  O.strOption
+    ( O.long "otelcol-certificate-store"
+        <> O.metavar "FILE"
+        <> O.help "Store for certificate validation."
+    )
+
+otelcolHeaderParser :: O.Parser HttpHeader
+otelcolHeaderParser =
+  O.option
+    ( O.eitherReader $ \header ->
+        case break (== '=') header of
+          ("", _) -> Left "Header name must not be empty."
+          (_, "") -> Left "Header must have the form NAME=VALUE."
+          (httpHeaderName, _ : httpHeaderValue) -> Right HttpHeader{..}
+    )
+    ( O.long "otelcol-header"
+        <> O.metavar "NAME=VALUE"
+        <> O.help "Add an HTTP header for OTLP HTTP/protobuf. May be repeated."
+    )
 
 otelcolSslKeyLogParser :: O.Parser G.SslKeyLog
 otelcolSslKeyLogParser =
-  asum
+  O.asum
     [ G.SslKeyLogPath
         <$> O.strOption
           ( O.long "otelcol-ssl-key-log"
               <> O.metavar "FILE"
               <> O.help "Use file to log SSL keys."
           )
-    , O.flag
-        G.SslKeyLogNone
+    , O.flag'
         G.SslKeyLogFromEnv
         ( O.long "otelcol-ssl-key-log-from-env"
             <> O.help "Use SSLKEYLOGFILE to log SSL keys."

--- a/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Options.hs
+++ b/eventlog-live-otelcol/src/GHC/Eventlog/Live/Otelcol/Options.hs
@@ -2,14 +2,15 @@ module GHC.Eventlog.Live.Otelcol.Options (
   Options (..),
   MyDebugOptions (..),
   ServiceName (..),
-  OpenTelemetryCollectorOptions (..),
-  OpenTelemetryCollectorProtocol (..),
-  HttpProtobufOptions (..),
-  HttpHeader (..),
+  OtlpExporterOptions (..),
+  OtlpProtocol (..),
   options,
 ) where
 
+import Data.Char (toLower)
 import Data.Default (Default (..))
+import Data.Functor (void)
+import Data.List qualified as L
 import Data.Text qualified as T
 import Data.Version (showVersion)
 import GHC.Debug.Stub.Compat (MyGhcDebugSocket, maybeMyGhcDebugSocketParser)
@@ -27,7 +28,10 @@ import Network.GRPC.Common qualified as G
 import Options.Applicative qualified as O
 import Options.Applicative.Compat qualified as OC
 import Options.Applicative.Extra qualified as OE
+import Options.Applicative.Help.Pretty qualified as OP
 import Paths_eventlog_live_otelcol qualified as EventlogLive
+import Text.ParserCombinators.ReadP (ReadP)
+import Text.ParserCombinators.ReadP qualified as P
 
 options :: O.ParserInfo Options
 options =
@@ -54,7 +58,7 @@ data Options = Options
   , severityThreshold :: Severity
   , stats :: Bool
   , maybeConfigFile :: Maybe FilePath
-  , openTelemetryCollectorOptions :: OpenTelemetryCollectorOptions
+  , otlpExporterOptions :: OtlpExporterOptions String
   , controlOptions :: ControlOptions
   , myDebugOptions :: MyDebugOptions
   }
@@ -74,7 +78,7 @@ optionsParser =
     <*> verbosityParser
     <*> statsParser
     <*> O.optional configFileParser
-    <*> openTelemetryCollectorOptionsParser
+    <*> otlpExporterOptionsParser
     <*> controlOptionsParser
     <*> myDebugOptionsParser
 
@@ -151,126 +155,102 @@ ccDBPathParser =
 --------------------------------------------------------------------------------
 -- OpenTelemetry Collector configuration
 
-data OpenTelemetryCollectorOptions = OpenTelemetryCollectorOptions
-  { openTelemetryCollectorProtocol :: OpenTelemetryCollectorProtocol
-  , otelcolHost :: String
-  , maybeOtelcolPort :: Maybe Int
-  , maybeOtelcolAuthority :: Maybe String
-  , otelcolSsl :: Bool
-  , maybeOtelcolCertificateStore :: Maybe FilePath
-  , maybeOtelcolSslKeyLog :: Maybe G.SslKeyLog
-  , otelcolHeaders :: [HttpHeader]
+data OtlpExporterOptions a = OtlpExporterOptions
+  { otlpProtocol :: !OtlpProtocol
+  , otlpEndpoint :: !a
+  , otlpGrpcCertificateStore :: !(Maybe FilePath)
+  , otlpGrpcSslKeyLog :: !(Maybe G.SslKeyLog)
+  , otlpHttpHeaders :: !(Maybe [(String, String)])
   }
+  deriving stock (Functor, Foldable, Traversable)
 
-data OpenTelemetryCollectorProtocol
-  = OpenTelemetryCollectorProtocol'Grpc
-  | OpenTelemetryCollectorProtocol'HttpProtobuf
-  deriving (Eq, Show)
+otlpExporterOptionsParser :: O.Parser (OtlpExporterOptions String)
+otlpExporterOptionsParser =
+  OC.parserOptionGroup "OTLP Exporter Options" $
+    OtlpExporterOptions
+      <$> otlpProtocolParser
+      <*> otlpEndpointParser
+      <*> O.optional otlpGrpcCertificateStoreParser
+      <*> O.optional otlpGrpcSslKeyLogParser
+      <*> O.optional otlpHttpHeadersParser
 
-data HttpProtobufOptions = HttpProtobufOptions
-  { httpProtobufScheme :: String
-  , httpProtobufHost :: String
-  , httpProtobufPort :: Int
-  , httpProtobufHeaders :: [HttpHeader]
-  }
+data OtlpProtocol
+  = OtlpProtocolGrpc
+  | OtlpProtocolHttpProtobuf
   deriving (Show)
 
-data HttpHeader = HttpHeader
-  { httpHeaderName :: String
-  , httpHeaderValue :: String
-  }
-  deriving (Show)
+otlpProtocolParser :: O.Parser OtlpProtocol
+otlpProtocolParser =
+  O.option (O.maybeReader readOtlpProtocol) . mconcat $
+    [ O.long "otlp-protocol"
+    , O.helpDoc . Just . OP.vcat . fmap OP.pretty $
+        [ "The OTLP transport protocol to be used for all telemetry data (gRPC, HTTP/Protobuf)."
+        , "Default value: gRPC"
+        ]
+    , O.value OtlpProtocolGrpc
+    ]
+ where
+  readOtlpProtocol :: String -> Maybe OtlpProtocol
+  readOtlpProtocol protocol =
+    case map toLower protocol of
+      "grpc" -> Just OtlpProtocolGrpc
+      "http/protobuf" -> Just OtlpProtocolHttpProtobuf
+      _ -> Nothing
 
-openTelemetryCollectorOptionsParser :: O.Parser OpenTelemetryCollectorOptions
-openTelemetryCollectorOptionsParser =
-  OC.parserOptionGroup "OpenTelemetry Collector Server Options" $
-    OpenTelemetryCollectorOptions
-      <$> otelcolProtocolParser
-      <*> otelcolHostParser
-      <*> O.optional otelcolPortParser
-      <*> O.optional otelcolAuthorityParser
-      <*> O.switch (O.long "otelcol-ssl" <> O.help "Use SSL.")
-      <*> O.optional otelcolCertificateStoreParser
-      <*> O.optional otelcolSslKeyLogParser
-      <*> O.many otelcolHeaderParser
+otlpEndpointParser :: O.Parser String
+otlpEndpointParser =
+  O.strOption . mconcat $
+    [ O.long "otlp-endpoint"
+    , O.helpDoc . Just . OP.vcat . fmap OP.pretty $
+        [ "The OTLP endpoint URL for all telemetry data, with an optionally-specified port number."
+        , "Default value:"
+        , "  gRPC: http://localhost:4317"
+        , "  HTTP: http://localhost:4318"
+        , "Example:"
+        , "  gRPC: https://my-api-endpoint:443"
+        , "  HTTP: http://my-api-endpoint/"
+        ]
+    ]
 
-otelcolProtocolParser :: O.Parser OpenTelemetryCollectorProtocol
-otelcolProtocolParser =
-  O.option
-    ( O.eitherReader $ \case
-        "grpc" -> Right OpenTelemetryCollectorProtocol'Grpc
-        "http/protobuf" -> Right OpenTelemetryCollectorProtocol'HttpProtobuf
-        protocol -> Left $ "Unknown OpenTelemetry Collector protocol: " <> protocol
-    )
-    ( O.long "otelcol-protocol"
-        <> O.metavar "grpc|http/protobuf"
-        <> O.help "OpenTelemetry Collector protocol."
-        <> O.value OpenTelemetryCollectorProtocol'Grpc
-        <> O.showDefaultWith (const "grpc")
-    )
-
-otelcolHostParser :: O.Parser String
-otelcolHostParser =
+otlpGrpcCertificateStoreParser :: O.Parser FilePath
+otlpGrpcCertificateStoreParser =
   O.strOption
-    ( O.long "otelcol-host"
-        <> O.metavar "HOST"
-        <> O.help "Otelcol server hostname."
-    )
-
-otelcolPortParser :: O.Parser Int
-otelcolPortParser =
-  O.option
-    O.auto
-    ( O.long "otelcol-port"
-        <> O.metavar "PORT"
-        <> O.help "Otelcol server TCP port. Defaults to 4317 for gRPC and 4318 for HTTP/protobuf."
-    )
-
-otelcolAuthorityParser :: O.Parser String
-otelcolAuthorityParser =
-  O.strOption
-    ( O.long "otelcol-authority"
-        <> O.metavar "HOST"
-        <> O.help "Otelcol server authority."
-    )
-
-otelcolCertificateStoreParser :: O.Parser FilePath
-otelcolCertificateStoreParser =
-  O.strOption
-    ( O.long "otelcol-certificate-store"
+    ( O.long "otlp-grpc-certificate-store"
         <> O.metavar "FILE"
         <> O.help "Store for certificate validation."
     )
 
-otelcolHeaderParser :: O.Parser HttpHeader
-otelcolHeaderParser =
-  O.option
-    ( O.eitherReader $ \header ->
-        case break (== '=') header of
-          ("", _) -> Left "Header name must not be empty."
-          (_, "") -> Left "Header must have the form NAME=VALUE."
-          (httpHeaderName, _ : httpHeaderValue) -> Right HttpHeader{..}
-    )
-    ( O.long "otelcol-header"
-        <> O.metavar "NAME=VALUE"
-        <> O.help "Add an HTTP header for OTLP HTTP/protobuf. May be repeated."
-    )
-
-otelcolSslKeyLogParser :: O.Parser G.SslKeyLog
-otelcolSslKeyLogParser =
+otlpGrpcSslKeyLogParser :: O.Parser G.SslKeyLog
+otlpGrpcSslKeyLogParser =
   O.asum
     [ G.SslKeyLogPath
         <$> O.strOption
-          ( O.long "otelcol-ssl-key-log"
+          ( O.long "otlp-grpc-ssl-key-log"
               <> O.metavar "FILE"
               <> O.help "Use file to log SSL keys."
           )
     , O.flag'
         G.SslKeyLogFromEnv
-        ( O.long "otelcol-ssl-key-log-from-env"
+        ( O.long "otlp-grpc-ssl-key-log-from-env"
             <> O.help "Use SSLKEYLOGFILE to log SSL keys."
         )
     ]
+
+otlpHttpHeadersParser :: O.Parser [(String, String)]
+otlpHttpHeadersParser =
+  O.option (O.maybeReader readHeaders) . mconcat $
+    [ O.long "otlp-http-headers"
+    , O.help "A list of headers to apply to all outgoing data."
+    ]
+
+readHeaders :: String -> Maybe [(String, String)]
+readHeaders = runReadP pHeaders
+ where
+  pHeaders :: ReadP [(String, String)]
+  pHeaders = P.many (pHeader <* (void (P.char ',') P.<++ P.eof))
+
+  pHeader :: ReadP (String, String)
+  pHeader = (,) <$> P.munch1 (/= '=') <*> P.munch1 (/= ',')
 
 --------------------------------------------------------------------------------
 -- Debug Options
@@ -286,3 +266,15 @@ myDebugOptionsParser =
     MyDebugOptions
       <$> maybeMyEventlogSocketParser
       <*> maybeMyGhcDebugSocketParser
+
+--------------------------------------------------------------------------------
+-- Internal helpers
+--------------------------------------------------------------------------------
+
+{- |
+Internal helper.
+
+Run a ReadP parser.
+-}
+runReadP :: ReadP a -> String -> Maybe a
+runReadP p = fmap fst . L.find (null . snd) . P.readP_to_S p

--- a/eventlog-live-tests/src/GHC/Eventlog/Live/Test.hs
+++ b/eventlog-live-tests/src/GHC/Eventlog/Live/Test.hs
@@ -337,7 +337,7 @@ withEventlogLiveOtelcol eventlogLiveOtelcolOptions action = do
   -- Configure the otelcol socket.
   let OtlpServerInfo{..} = ?otlpServerInfo
   let otelcolArgs =
-        ["--otelcol-host=" <> host, "--otelcol-port=" <> show port]
+        ["--otlp-endpoint=" <> host <> ":" <> show port]
 
   -- Create the temporary configuration file, if needed.
   withTempConfigFile eventlogLiveOtelcolOptions.maybeConfigBody $ \configArgs -> do

--- a/examples/eventlog-live-otelcol/eventlog-live-otelcol-otelcol.sh
+++ b/examples/eventlog-live-otelcol/eventlog-live-otelcol-otelcol.sh
@@ -58,7 +58,7 @@ echo 'Start eventlog-live-otelcol (for oddball)' && \
 	    --eventlog-socket '$GHC_EVENTLOG_SOCKET' \
 		--enable-my-eventlog-socket-unix '$MY_GHC_EVENTLOG_SOCKET' \
 	    -hT \
-	    --otelcol-host=localhost \
+	    --otlp-endpoint=localhost \
 		+RTS -l -hT --eventlog-flush-interval=1 -RTS
 "
 
@@ -74,7 +74,7 @@ ${EVENTLOG_LIVE_OTELCOL_BIN} \
 	--eventlog-flush-interval=1 \
     --eventlog-socket '$MY_GHC_EVENTLOG_SOCKET' \
     -hT \
-    --otelcol-host=localhost
+    --otlp-endpoint=localhost
 "
 
 # Create the screen conf file

--- a/examples/ghc/ghc-otelcol.sh
+++ b/examples/ghc/ghc-otelcol.sh
@@ -122,7 +122,7 @@ echo 'Start eventlog-live-otelcol' && \
 		--service-name='ghc' \
 	    --eventlog-socket '$GHC_EVENTLOG_UNIX_PATH' \
 	    -hT \
-	    --otelcol-host=localhost
+	    --otlp-endpoint=localhost
 "
 
 # Create the screen conf file

--- a/examples/jumpy-jump/jumpy-jump-otelcol-with-cost-centre-profiler.sh
+++ b/examples/jumpy-jump/jumpy-jump-otelcol-with-cost-centre-profiler.sh
@@ -56,7 +56,7 @@ echo 'Start eventlog-live-otelcol (for jumpy-jump)' && \
 		--service-name='jumpy-jump' \
 	    --eventlog-socket '$GHC_EVENTLOG_UNIX_PATH' \
 	    -hT \
-	    --otelcol-host=localhost \
+	    --otlp-endpoint=localhost \
 		--control \
 		--control-port 30719 \
 		--control-cors-ignore-failure

--- a/examples/jumpy-jump/jumpy-jump-otelcol-with-ghc-stack-profiler.sh
+++ b/examples/jumpy-jump/jumpy-jump-otelcol-with-ghc-stack-profiler.sh
@@ -58,7 +58,7 @@ echo 'Start eventlog-live-otelcol (for jumpy-jump)' && \
 		--service-name='jumpy-jump' \
 	    --eventlog-socket '$GHC_EVENTLOG_UNIX_PATH' \
 	    -hT \
-	    --otelcol-host=localhost \
+	    --otlp-endpoint=localhost \
 		--control \
 		--control-port 30719 \
 		--control-cors-ignore-failure

--- a/examples/oddball/oddball-otelcol-with-hT.sh
+++ b/examples/oddball/oddball-otelcol-with-hT.sh
@@ -53,7 +53,7 @@ echo 'Start eventlog-live-otelcol (for oddball)' && \
 	    --eventlog-socket '$GHC_EVENTLOG_UNIX_PATH' \
 	    -hT \
 		--eventlog-flush-interval=1 \
-	    --otelcol-host=localhost \
+	    --otlp-endpoint=localhost \
 		--control \
 		--control-port 30719 \
 		--control-cors-ignore-failure

--- a/examples/oddball/oddball-otelcol-with-hi.sh
+++ b/examples/oddball/oddball-otelcol-with-hi.sh
@@ -59,7 +59,7 @@ echo 'Start eventlog-live-otelcol (for oddball)' && \
 	    --eventlog-socket '$GHC_EVENTLOG_UNIX_PATH' \
 	    -hi \
 		--eventlog-flush-interval=1 \
-	    --otelcol-host=localhost \
+	    --otlp-endpoint=localhost \
 		--control \
 		--control-port 30719 \
 		--control-cors-ignore-failure

--- a/examples/oddball/oddball-otelcol-with-inet.sh
+++ b/examples/oddball/oddball-otelcol-with-inet.sh
@@ -55,7 +55,7 @@ echo 'Start eventlog-live-otelcol (for oddball)' && \
 		--eventlog-socket-port '$GHC_EVENTLOG_INET_PORT' \
 	    -hT \
 		--eventlog-flush-interval=1 \
-	    --otelcol-host=localhost \
+	    --otlp-endpoint=localhost \
 		--control \
 		--control-port 30719 \
 		--control-cors-ignore-failure

--- a/examples/spectral-norm/spectral-norm-otelcol.sh
+++ b/examples/spectral-norm/spectral-norm-otelcol.sh
@@ -54,7 +54,7 @@ echo 'Start eventlog-live-otelcol (for spectral-norm)' && \
 		--service-name='spectral-norm' \
 	    --eventlog-socket '$GHC_EVENTLOG_SOCKET' \
 	    -hT \
-	    --otelcol-host=localhost \
+	    --otlp-endpoint=localhost \
 		+RTS -l -hT --eventlog-flush-interval=1 -RTS
 "
 


### PR DESCRIPTION
This PR merges the HTTP/Protobuf by @edmundnoble with minor changes.

TODO:

- [x] Add a demo that uses HTTP/Protobuf, e.g., by sending metrics directly to Prometheus.
- [ ] Add an HTTP/Protobuf server to `eventlog-live-tests`.
- [ ] Write an HTTP/Protobuf test.